### PR TITLE
feat: automate pubspec dependency setup

### DIFF
--- a/codex/daten/changelog.md
+++ b/codex/daten/changelog.md
@@ -18,3 +18,6 @@
 
 ### Phase 1: Flutter-Projekt mit Multi-Platform-Support - 2025-08-07
 - Skript `scripts/create_flutter_project.sh` hinzugefügt, das das Projekt automatisch erzeugt und anpasst
+
+### Phase 1: pubspec.yaml mit Dependencies konfiguriert - 2025-08-07
+- `scripts/create_flutter_project.sh` erweitert, um benötigte Dependencies und Dev-Dependencies in `pubspec.yaml` automatisch einzutragen

--- a/codex/daten/prompt.md
+++ b/codex/daten/prompt.md
@@ -1,8 +1,9 @@
-# Nächster Schritt: Phase 1 – `pubspec.yaml` mit erforderlichen Dependencies konfigurieren
+# Nächster Schritt: Phase 1 – `Basis App-Struktur mit Material App konfigurieren`
 
 ## Status
 - Phase 0 abgeschlossen ✓
 - Flutter SDK installiert (3.32.8)
+- `pubspec.yaml` mit Dependencies konfiguriert
 - Flutter-Projekt wird bei Bedarf durch `scripts/create_flutter_project.sh` erzeugt
 
 ## Referenzen
@@ -11,21 +12,20 @@
 - `/codex/daten/roadmap.md`
 - `/codex/daten/changelog.md`
 
-## Nächste Aufgabe: `pubspec.yaml` mit erforderlichen Dependencies konfigurieren
+## Nächste Aufgabe: `Basis App-Struktur mit Material App konfigurieren`
 
 ### Vorbereitungen
 - Führe bei Bedarf `scripts/create_flutter_project.sh` aus, um die Projektstruktur zu generieren.
-- Navigiere zu `flutter_app/mrs_unkwn_app`.
+- Navigiere zu `flutter_app/mrs_unkwn_app/lib`.
 
 ### Implementierungsschritte
-- Öffne `pubspec.yaml`.
-- Füge unter `dependencies:` hinzu: `dio: ^5.3.0`, `flutter_bloc: ^8.1.3`, `get_it: ^7.6.0`, `flutter_secure_storage: ^9.0.0`, `go_router: ^12.0.0`, `hive: ^2.2.3`, `json_annotation: ^4.8.1`.
-- Füge unter `dev_dependencies:` hinzu: `build_runner: ^2.4.7`, `json_serializable: ^6.7.1`, `flutter_test:` und `mocktail: ^1.0.0`.
-- Speichere die Datei.
+- Erstelle `lib/app.dart`.
+- Implementiere `MrsUnkwnApp` Klasse, die `StatelessWidget` erweitert.
+- Gib in `build()` `MaterialApp` zurück mit `title: 'Mrs-Unkwn'`, `theme: ThemeData(primarySwatch: Colors.blue)`, `home: Placeholder()`.
+- Importiere `app.dart` in `lib/main.dart` und rufe `runApp(MrsUnkwnApp())` in `main()` auf.
 
 ### Validierung
-- `grep dio pubspec.yaml` (innerhalb des Projektordners)
+- `grep MrsUnkwnApp lib/main.dart` (innerhalb des Projektordners)
 
 ### Selbstgenerierung
 - Schreibe nach Abschluss dieses Schrittes automatisch den nächsten Prompt zum Weiterarbeiten in `/codex/daten/prompt.md`.
-

--- a/codex/daten/roadmap.md
+++ b/codex/daten/roadmap.md
@@ -22,7 +22,7 @@ Details: Lade Flutter SDK von flutter.dev herunter. Extrahiere das SDK nach `C:\
 [x] Flutter-Projekt mit Multi-Platform-Support erstellen:
 Details: Navigiere in den `flutter_app/`-Ordner. Führe `flutter create --org com.mrsunkwn --platforms android,ios,web,windows,macos,linux mrs_unkwn_app` aus. Öffne `pubspec.yaml` und setze `flutter` Version auf minimum "3.16.0". Entferne Standard-Demo-Code aus `lib/main.dart`. Erstelle Basis-Ordnerstruktur in `lib/`: `core/`, `features/`, `shared/`, `platform_channels/`.
 
-[ ] pubspec.yaml mit erforderlichen Dependencies konfigurieren:
+[x] pubspec.yaml mit erforderlichen Dependencies konfigurieren:
 Details: Öffne `pubspec.yaml` und füge folgende dependencies hinzu unter `dependencies:`: `dio: ^5.3.0` (HTTP client), `flutter_bloc: ^8.1.3` (State Management), `get_it: ^7.6.0` (Dependency Injection), `flutter_secure_storage: ^9.0.0` (Secure Storage), `go_router: ^12.0.0` (Navigation), `hive: ^2.2.3` (Local Database), `json_annotation: ^4.8.1` (JSON Serialization). Unter `dev_dependencies:` füge hinzu: `build_runner: ^2.4.7`, `json_serializable: ^6.7.1`, `flutter_test:`, `mocktail: ^1.0.0`.
 
 [ ] Basis App-Struktur mit Material App konfigurieren:

--- a/scripts/create_flutter_project.sh
+++ b/scripts/create_flutter_project.sh
@@ -19,6 +19,14 @@ fi
 PUBSPEC="$TARGET_DIR/pubspec.yaml"
 if [ -f "$PUBSPEC" ]; then
   perl -0pi -e 's/sdk: ">=([0-9]+\.[0-9]+\.[0-9]+)/sdk: ">=3.16.0/' "$PUBSPEC"
+
+  if ! grep -q "dio:" "$PUBSPEC"; then
+    perl -0pi -e 's/dependencies:\n/dependencies:\n  dio: ^5.3.0\n  flutter_bloc: ^8.1.3\n  get_it: ^7.6.0\n  flutter_secure_storage: ^9.0.0\n  go_router: ^12.0.0\n  hive: ^2.2.3\n  json_annotation: ^4.8.1\n/' "$PUBSPEC"
+  fi
+
+  if ! grep -q "mocktail:" "$PUBSPEC"; then
+    perl -0pi -e 's/dev_dependencies:\n/dev_dependencies:\n  build_runner: ^2.4.7\n  json_serializable: ^6.7.1\n  flutter_test:\n    sdk: flutter\n  mocktail: ^1.0.0\n/' "$PUBSPEC"
+  fi
 fi
 
 MAIN_DART="$TARGET_DIR/lib/main.dart"


### PR DESCRIPTION
## Summary
- extend project creation script to inject required dependencies into pubspec.yaml
- mark dependency setup complete in roadmap and changelog
- add next development prompt for configuring basic Material app structure

## Testing
- `bash scripts/create_flutter_project.sh`
- `grep dio flutter_app/mrs_unkwn_app/pubspec.yaml`


------
https://chatgpt.com/codex/tasks/task_e_6894fcfb1f18832ea2793317b5193682