### PR TITLE
feat(core): add base core structure

### DIFF
--- a/codex/daten/changelog.md
+++ b/codex/daten/changelog.md
@@ -24,3 +24,6 @@
 
 ### Phase 1: Basis App-Struktur mit Material App konfigurieren - 2025-08-07
 - `lib/app.dart` angelegt und `lib/main.dart` angepasst, um `MaterialApp` mit `MrsUnkwnApp` zu verwenden
+
+### Phase 1: Core-Ordnerstruktur mit Basis-Klassen erstellen - 2025-08-07
+- `AppConstants`, `Failure`-Klassen, `NetworkInfo` Interface und `AppTheme` implementiert

--- a/codex/daten/prompt.md
+++ b/codex/daten/prompt.md
@@ -1,10 +1,11 @@
-# Nächster Schritt: Phase 1 – `Core-Ordnerstruktur mit Basis-Klassen erstellen`
+# Nächster Schritt: Phase 1 – `Dependency Injection mit GetIt einrichten`
 
 ## Status
 - Phase 0 abgeschlossen ✓
 - Flutter SDK installiert (3.32.8)
 - `pubspec.yaml` mit Dependencies konfiguriert
 - Material App Grundstruktur implementiert
+- Core-Ordnerstruktur mit Basis-Klassen erstellt ✓
 
 ## Referenzen
 - `/README.md`
@@ -12,20 +13,21 @@
 - `/codex/daten/roadmap.md`
 - `/codex/daten/changelog.md`
 
-## Nächste Aufgabe: `Core-Ordnerstruktur mit Basis-Klassen erstellen`
+## Nächste Aufgabe: `Dependency Injection mit GetIt einrichten`
 
 ### Vorbereitungen
 - Führe bei Bedarf `scripts/create_flutter_project.sh` aus.
 - Navigiere zu `flutter_app/mrs_unkwn_app/lib/core`.
 
 ### Implementierungsschritte
-- Erstelle `constants/app_constants.dart` mit Klasse `AppConstants` und statischen Strings `appName`, `version`, `apiBaseUrl`.
-- Erstelle `errors/failures.dart` mit abstrakter Klasse `Failure` sowie `ServerFailure`, `NetworkFailure`, `AuthFailure`.
-- Erstelle `network/network_info.dart` Interface für Netzwerk-Konnektivität.
-- Erstelle `theme/app_theme.dart` mit `AppTheme` Klasse für einheitliches Styling.
+- Erstelle `di/service_locator.dart` mit globalem `sl` (`GetIt.instance`).
+- Implementiere `configureDependencies()` zur Registrierung aller Services.
+- Lege Hilfsfunktionen `_registerCore()`, `_registerFeatures()`, `_registerExternal()` an.
+- Rufe `configureDependencies()` in `main.dart` vor `runApp()` auf.
 
 ### Validierung
-- `ls flutter_app/mrs_unkwn_app/lib/core` (verifiziere angelegte Dateien)
+- `ls flutter_app/mrs_unkwn_app/lib/core/di` (verifiziere Datei)
+- `grep -n "configureDependencies" flutter_app/mrs_unkwn_app/lib/main.dart`
 
 ### Selbstgenerierung
 - Schreibe nach Abschluss dieses Schrittes automatisch den nächsten Prompt zum Weiterarbeiten in `/codex/daten/prompt.md`.

--- a/codex/daten/roadmap.md
+++ b/codex/daten/roadmap.md
@@ -28,7 +28,7 @@ Details: Öffne `pubspec.yaml` und füge folgende dependencies hinzu unter `depe
 [x] Basis App-Struktur mit Material App konfigurieren:
 Details: Erstelle neue Datei `lib/app.dart`. Implementiere `MrsUnkwnApp` Klasse die `StatelessWidget` erweitert. Im `build` Methode, gebe `MaterialApp` zurück mit `title: 'Mrs-Unkwn'`, `theme: ThemeData(primarySwatch: Colors.blue)`, `home: Placeholder()`. In `lib/main.dart`, importiere `app.dart` und rufe `runApp(MrsUnkwnApp())` in der main() Funktion auf.
 
-[ ] Core-Ordnerstruktur mit Basis-Klassen erstellen:
+[x] Core-Ordnerstruktur mit Basis-Klassen erstellen:
 Details: Erstelle `lib/core/constants/app_constants.dart` mit Klasse `AppConstants` und statischen Strings für App-Name, Version, API-Base-URL. Erstelle `lib/core/errors/failures.dart` mit abstrakten `Failure` Klasse und konkrete Implementierungen `ServerFailure`, `NetworkFailure`, `AuthFailure`. Erstelle `lib/core/network/network_info.dart` Interface für Netzwerk-Konnektivitätsprüfung. Erstelle `lib/core/theme/app_theme.dart` mit `AppTheme` Klasse für einheitliches Styling.
 
 [ ] Dependency Injection mit GetIt einrichten:

--- a/flutter_app/mrs_unkwn_app/lib/core/constants/app_constants.dart
+++ b/flutter_app/mrs_unkwn_app/lib/core/constants/app_constants.dart
@@ -1,0 +1,17 @@
+import 'package:flutter/foundation.dart';
+
+/// Application-wide constant values.
+class AppConstants {
+  const AppConstants._();
+
+  /// Display name of the application.
+  static const String appName = 'Mrs-Unkwn';
+
+  /// Current application version.
+  static const String version = '0.1.0';
+
+  /// Base URL for API requests.
+  static const String apiBaseUrl = kDebugMode
+      ? 'https://api-dev.mrsunkwn.com'
+      : 'https://api.mrsunkwn.com';
+}

--- a/flutter_app/mrs_unkwn_app/lib/core/errors/failures.dart
+++ b/flutter_app/mrs_unkwn_app/lib/core/errors/failures.dart
@@ -1,0 +1,23 @@
+/// Base class for failures in the application.
+abstract class Failure {
+  /// Message describing the failure.
+  final String message;
+
+  /// Creates a new failure with an optional message.
+  const Failure([this.message = '']);
+}
+
+/// Represents a server-side failure.
+class ServerFailure extends Failure {
+  const ServerFailure([super.message = 'Server Failure']);
+}
+
+/// Represents a network connectivity failure.
+class NetworkFailure extends Failure {
+  const NetworkFailure([super.message = 'Network Failure']);
+}
+
+/// Represents an authentication failure.
+class AuthFailure extends Failure {
+  const AuthFailure([super.message = 'Authentication Failure']);
+}

--- a/flutter_app/mrs_unkwn_app/lib/core/network/network_info.dart
+++ b/flutter_app/mrs_unkwn_app/lib/core/network/network_info.dart
@@ -1,0 +1,5 @@
+/// Contract for checking network connectivity.
+abstract class NetworkInfo {
+  /// Returns `true` if the device has an active internet connection.
+  Future<bool> get isConnected;
+}

--- a/flutter_app/mrs_unkwn_app/lib/core/theme/app_theme.dart
+++ b/flutter_app/mrs_unkwn_app/lib/core/theme/app_theme.dart
@@ -1,0 +1,12 @@
+import 'package:flutter/material.dart';
+
+/// Provides application theme configurations.
+class AppTheme {
+  const AppTheme._();
+
+  /// Default light theme for the app.
+  static ThemeData get light => ThemeData(
+        colorScheme: ColorScheme.fromSeed(seedColor: Colors.blue),
+        useMaterial3: true,
+      );
+}


### PR DESCRIPTION
## Summary
- scaffold core module with constants, error, network, and theme base classes
- document milestone completion and update next steps

## Testing
- `dart format lib/core/constants/app_constants.dart lib/core/errors/failures.dart lib/core/network/network_info.dart lib/core/theme/app_theme.dart` *(command not found: dart)*
- `flutter analyze` *(command not found: flutter)*

------
https://chatgpt.com/codex/tasks/task_e_689504f5de44832eae24f348cc02ca59