### PR TITLE
feat: add GetIt service locator

### DIFF
--- a/codex/daten/changelog.md
+++ b/codex/daten/changelog.md
@@ -27,3 +27,7 @@
 
 ### Phase 1: Core-Ordnerstruktur mit Basis-Klassen erstellen - 2025-08-07
 - `AppConstants`, `Failure`-Klassen, `NetworkInfo` Interface und `AppTheme` implementiert
+
+### Phase 1: Dependency Injection mit GetIt einrichten - 2025-08-07
+- `service_locator.dart` erstellt und `configureDependencies()` eingebunden
+- `main.dart` angepasst, um `configureDependencies()` vor `runApp` aufzurufen

--- a/codex/daten/prompt.md
+++ b/codex/daten/prompt.md
@@ -1,4 +1,4 @@
-# Nächster Schritt: Phase 1 – `Dependency Injection mit GetIt einrichten`
+# Nächster Schritt: Phase 1 – `Flutter BLoC Setup mit Basis-Strukturen`
 
 ## Status
 - Phase 0 abgeschlossen ✓
@@ -6,6 +6,7 @@
 - `pubspec.yaml` mit Dependencies konfiguriert
 - Material App Grundstruktur implementiert
 - Core-Ordnerstruktur mit Basis-Klassen erstellt ✓
+- Dependency Injection mit GetIt eingerichtet ✓
 
 ## Referenzen
 - `/README.md`
@@ -13,23 +14,21 @@
 - `/codex/daten/roadmap.md`
 - `/codex/daten/changelog.md`
 
-## Nächste Aufgabe: `Dependency Injection mit GetIt einrichten`
+## Nächste Aufgabe: `Flutter BLoC Setup mit Basis-Strukturen`
 
 ### Vorbereitungen
-- Führe bei Bedarf `scripts/create_flutter_project.sh` aus.
 - Navigiere zu `flutter_app/mrs_unkwn_app/lib/core`.
 
 ### Implementierungsschritte
-- Erstelle `di/service_locator.dart` mit globalem `sl` (`GetIt.instance`).
-- Implementiere `configureDependencies()` zur Registrierung aller Services.
-- Lege Hilfsfunktionen `_registerCore()`, `_registerFeatures()`, `_registerExternal()` an.
-- Rufe `configureDependencies()` in `main.dart` vor `runApp()` auf.
+- Erstelle `bloc/base_event.dart` und `bloc/base_state.dart` mit abstrakten Klassen.
+- Implementiere `bloc/base_bloc.dart` mit Standard-Error-Handling und Logging.
+- Erstelle `bloc/bloc_observer.dart` zur globalen BLoC-Überwachung.
 
 ### Validierung
-- `ls flutter_app/mrs_unkwn_app/lib/core/di` (verifiziere Datei)
-- `grep -n "configureDependencies" flutter_app/mrs_unkwn_app/lib/main.dart`
+- `ls flutter_app/mrs_unkwn_app/lib/core/bloc`
+- `grep -n "class BaseBloc" flutter_app/mrs_unkwn_app/lib/core/bloc/base_bloc.dart`
 
 ### Selbstgenerierung
-- Schreibe nach Abschluss dieses Schrittes automatisch den nächsten Prompt zum Weiterarbeiten in `/codex/daten/prompt.md`.
+- Schreibe nach Abschluss dieses Schrittes automatisch den nächsten Prompt in `/codex/daten/prompt.md`.
 
-*Hinweis: Halte den Codeumfang dieses Sprints unter 500 Zeilen.*
+*Hinweis: Codex kann keine Binärdateien mergen. Benötigte Dateien müssen durch Skripte generiert werden. Halte den Codeumfang dieses Sprints unter 500 Zeilen.*

--- a/codex/daten/roadmap.md
+++ b/codex/daten/roadmap.md
@@ -31,7 +31,7 @@ Details: Erstelle neue Datei `lib/app.dart`. Implementiere `MrsUnkwnApp` Klasse 
 [x] Core-Ordnerstruktur mit Basis-Klassen erstellen:
 Details: Erstelle `lib/core/constants/app_constants.dart` mit Klasse `AppConstants` und statischen Strings für App-Name, Version, API-Base-URL. Erstelle `lib/core/errors/failures.dart` mit abstrakten `Failure` Klasse und konkrete Implementierungen `ServerFailure`, `NetworkFailure`, `AuthFailure`. Erstelle `lib/core/network/network_info.dart` Interface für Netzwerk-Konnektivitätsprüfung. Erstelle `lib/core/theme/app_theme.dart` mit `AppTheme` Klasse für einheitliches Styling.
 
-[ ] Dependency Injection mit GetIt einrichten:
+[x] Dependency Injection mit GetIt einrichten:
 Details: Erstelle `lib/core/di/service_locator.dart`. Importiere `get_it` Package. Erstelle globale Variable `final sl = GetIt.instance;`. Implementiere `configureDependencies()` Funktion die alle Services registriert. Erstelle `_registerCore()`, `_registerFeatures()`, `_registerExternal()` Hilfsfunktionen. Rufe `configureDependencies()` in `main.dart` vor `runApp()` auf.
 
 [ ] Flutter BLoC Setup mit Basis-Strukturen:

--- a/flutter_app/mrs_unkwn_app/lib/core/di/service_locator.dart
+++ b/flutter_app/mrs_unkwn_app/lib/core/di/service_locator.dart
@@ -1,0 +1,21 @@
+import 'package:get_it/get_it.dart';
+
+final sl = GetIt.instance;
+
+Future<void> configureDependencies() async {
+  _registerCore();
+  _registerFeatures();
+  _registerExternal();
+}
+
+void _registerCore() {
+  // Register core services here
+}
+
+void _registerFeatures() {
+  // Register feature-specific services here
+}
+
+void _registerExternal() {
+  // Register external packages and APIs here
+}

--- a/flutter_app/mrs_unkwn_app/lib/main.dart
+++ b/flutter_app/mrs_unkwn_app/lib/main.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'app.dart';
+import 'core/di/service_locator.dart';
 
-void main() {
+Future<void> main() async {
+  await configureDependencies();
   runApp(const MrsUnkwnApp());
 }


### PR DESCRIPTION
## Summary
- add service locator with GetIt
- call configureDependencies before app start
- update roadmap, changelog, and next prompt

## Testing
- `ls flutter_app/mrs_unkwn_app/lib/core/di`
- `grep -n "configureDependencies" flutter_app/mrs_unkwn_app/lib/main.dart`
- `apt-get install -y dart` *(fails: Unable to locate package dart)*
- `dart format flutter_app/mrs_unkwn_app/lib` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689508ef1d80832eb476e983d743d7fc