### PR TITLE
feat: initialize express backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ flutter_app/mrs_unkwn_app/*
 node_modules/
 dist/
 .env
+package-lock.json
 
 # Python
 __pycache__/

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "backend",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "dependencies": {
+    "bcrypt": "^6.0.0",
+    "cors": "^2.8.5",
+    "dotenv": "^17.2.1",
+    "express": "^5.1.0",
+    "express-validator": "^7.2.1",
+    "helmet": "^8.1.0",
+    "jsonwebtoken": "^9.0.2",
+    "morgan": "^1.10.1"
+  },
+  "devDependencies": {
+    "@types/express": "^5.0.3",
+    "@types/node": "^24.2.0",
+    "nodemon": "^3.1.10",
+    "ts-node": "^10.9.2",
+    "typescript": "^5.9.2"
+  }
+}

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1,0 +1,3 @@
+import express from 'express';
+
+console.log('Server initialized');

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "rootDir": "src",
+    "outDir": "dist",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src/**/*"]
+}

--- a/codex/daten/changelog.md
+++ b/codex/daten/changelog.md
@@ -58,3 +58,9 @@
 - `BaseModel` mit `fromJson` und `toJson` implementiert
 - `flutter packages pub run build_runner build` ausgeführt
 - `.gitignore` angepasst, um `build.yaml` zu versionieren
+### Phase 1: Node.js Express Server initialisieren - 2025-08-07
+- `backend` Verzeichnis erstellt und Node-Projekt mit `npm init -y` initialisiert
+- Dependencies installiert: express, cors, helmet, morgan, dotenv, bcrypt, jsonwebtoken, express-validator
+- Dev-Dependencies installiert: nodemon, typescript, @types/node, @types/express, ts-node
+- `tsconfig.json` mit Node.js Standardkonfiguration hinzugefügt
+- `src/index.ts` als Entry-Point angelegt

--- a/codex/daten/prompt.md
+++ b/codex/daten/prompt.md
@@ -1,4 +1,4 @@
-# Nächster Schritt: Phase 1 – `Node.js Express Server initialisieren`
+# Nächster Schritt: Phase 1 – `Express Server Basis-Konfiguration`
 
 ## Status
 - Phase 0 abgeschlossen ✓
@@ -14,6 +14,7 @@
 - Environment Configuration System implementiert ✓
 - Error Handling und Logging System implementiert ✓
 - JSON Serialization Setup implementiert ✓
+- Node.js Express Server initialisiert ✓
 
 ## Referenzen
 - `/README.md`
@@ -21,22 +22,23 @@
 - `/codex/daten/roadmap.md`
 - `/codex/daten/changelog.md`
 
-## Nächste Aufgabe: `Node.js Express Server initialisieren`
+## Nächste Aufgabe: `Express Server Basis-Konfiguration`
 
 ### Vorbereitungen
 - Navigiere zum Projekt-Root `backend/`.
 
 ### Implementierungsschritte
-- `npm init -y` ausführen.
-- Dependencies installieren: `express cors helmet morgan dotenv bcrypt jsonwebtoken express-validator`.
-- Dev-Dependencies installieren: `nodemon typescript @types/node @types/express ts-node`.
-- `tsconfig.json` mit Node.js Standardkonfiguration erstellen.
-- Ordner `src/` mit Datei `index.ts` als Entry-Point anlegen.
+- In `src/index.ts` benötigte Module importieren: `express`, `cors`, `helmet`, `morgan`.
+- Express-App Instanz `const app = express()` erstellen.
+- Middleware konfigurieren: `app.use(cors())`, `app.use(helmet())`, `app.use(morgan('combined'))`, `app.use(express.json())`.
+- Port definieren: `const PORT = process.env.PORT || 3000`.
+- Server starten: `app.listen(PORT, callback)`.
+- Health-Check-Endpoint `app.get('/health', handler)` hinzufügen.
 
 ### Validierung
-- `ls backend`
-- `ls backend/src`
 - `npx tsc --noEmit`
+- `npx ts-node src/index.ts` (Server starten)
+- In neuem Terminal: `curl http://localhost:3000/health`
 
 ### Selbstgenerierung
 - Schreibe nach Abschluss dieses Schrittes automatisch den nächsten Prompt in `/codex/daten/prompt.md`.

--- a/codex/daten/roadmap.md
+++ b/codex/daten/roadmap.md
@@ -57,7 +57,7 @@ Details: Erstelle `build.yaml` im Projekt-Root für json_serializable Konfigurat
 
 ### Milestone 2: Backend API Foundation
 
-[ ] Node.js Express Server initialisieren:
+[x] Node.js Express Server initialisieren:
 Details: Navigiere in `backend/` Ordner. Führe `npm init -y` aus. Installiere Dependencies: `npm install express cors helmet morgan dotenv bcrypt jsonwebtoken express-validator`. Installiere Development-Dependencies: `npm install --save-dev nodemon typescript @types/node @types/express ts-node`. Erstelle `tsconfig.json` mit Standard-TypeScript-Konfiguration für Node.js. Erstelle `src/` Ordner mit `index.ts` als Entry-Point.
 
 [ ] Express Server Basis-Konfiguration:


### PR DESCRIPTION
## Summary
- set up Node.js backend scaffolding with Express and TypeScript
- document backend initialization and update next development prompt
- ignore package-lock to avoid committing generated artifacts

## Testing
- `ls backend`
- `ls backend/src`
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_689528cd2720832e8061c969c60ae668