### PR TITLE
feat: add environment configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ flutter_app/mrs_unkwn_app/*
 node_modules/
 dist/
 .env
+**/.env
 package-lock.json
 
 # Python

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,5 @@
+DATABASE_URL=postgresql://user:password@localhost:5432/mrsunkwn
+JWT_SECRET=changeme
+JWT_REFRESH_SECRET=changeme_refresh
+EMAIL_SERVICE_KEY=change_this_email_key
+NODE_ENV=development

--- a/backend/package.json
+++ b/backend/package.json
@@ -21,7 +21,9 @@
     "morgan": "^1.10.1"
   },
   "devDependencies": {
+    "@types/cors": "^2.8.19",
     "@types/express": "^5.0.3",
+    "@types/morgan": "^1.9.10",
     "@types/node": "^24.2.0",
     "nodemon": "^3.1.10",
     "ts-node": "^10.9.2",

--- a/backend/src/config/config.ts
+++ b/backend/src/config/config.ts
@@ -1,0 +1,41 @@
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+const required = [
+  'DATABASE_URL',
+  'JWT_SECRET',
+  'JWT_REFRESH_SECRET',
+  'EMAIL_SERVICE_KEY',
+  'NODE_ENV',
+] as const;
+
+type RequiredKeys = typeof required[number];
+
+export interface Config {
+  databaseUrl: string;
+  jwtSecret: string;
+  jwtRefreshSecret: string;
+  emailServiceKey: string;
+  nodeEnv: string;
+}
+
+function getConfig(): Config {
+  const env: Partial<Record<RequiredKeys, string>> = {};
+  for (const key of required) {
+    const value = process.env[key];
+    if (!value) {
+      throw new Error(`Missing environment variable: ${key}`);
+    }
+    env[key] = value;
+  }
+  return {
+    databaseUrl: env.DATABASE_URL!,
+    jwtSecret: env.JWT_SECRET!,
+    jwtRefreshSecret: env.JWT_REFRESH_SECRET!,
+    emailServiceKey: env.EMAIL_SERVICE_KEY!,
+    nodeEnv: env.NODE_ENV!,
+  };
+}
+
+export const config = getConfig();

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -2,6 +2,7 @@ import express from 'express';
 import cors from 'cors';
 import helmet from 'helmet';
 import morgan from 'morgan';
+import { config } from './config/config';
 
 const app = express();
 
@@ -17,6 +18,6 @@ app.get('/health', (_req, res) => {
 });
 
 app.listen(PORT, () => {
-  console.log(`Server listening on port ${PORT}`);
+  console.log(`Server listening on port ${PORT} in ${config.nodeEnv} mode`);
 });
 

--- a/codex/daten/changelog.md
+++ b/codex/daten/changelog.md
@@ -69,3 +69,9 @@
 - Express-App mit `cors`, `helmet`, `morgan` und JSON-Parsing konfiguriert
 - Health-Check-Endpoint `/health` implementiert
 - Serverstart auf konfigurierbarem Port umgesetzt
+
+### Phase 1: Environment Variables Setup - 2025-08-07
+- `.env.example` mit notwendigen Variablen erstellt
+- `src/config/config.ts` hinzugefügt und Variablenvalidierung implementiert
+- `.gitignore` erweitert, um `.env`-Dateien auszuschließen
+- `src/index.ts` lädt Konfiguration und protokolliert aktuelles Environment

--- a/codex/daten/prompt.md
+++ b/codex/daten/prompt.md
@@ -1,4 +1,4 @@
-# Nächster Schritt: Phase 1 – `Environment Variables Setup`
+# Nächster Schritt: Phase 1 – `Database Connection Setup mit PostgreSQL`
 
 ## Status
 - Phase 0 abgeschlossen ✓
@@ -16,6 +16,7 @@
 - JSON Serialization Setup implementiert ✓
 - Node.js Express Server initialisiert ✓
 - Express Server Basis-Konfiguration implementiert ✓
+- Environment Variables Setup implementiert ✓
 
 ## Referenzen
 - `/README.md`
@@ -23,21 +24,21 @@
 - `/codex/daten/roadmap.md`
 - `/codex/daten/changelog.md`
 
-## Nächste Aufgabe: `Environment Variables Setup`
+## Nächste Aufgabe: `Database Connection Setup mit PostgreSQL`
 
 ### Vorbereitungen
 - Navigiere zum Projekt-Root `backend/`.
 
 ### Implementierungsschritte
-- `.env.example` mit Variablen `DATABASE_URL`, `JWT_SECRET`, `JWT_REFRESH_SECRET`, `EMAIL_SERVICE_KEY`, `NODE_ENV` anlegen.
-- `.env` aus Vorlage generieren (nicht committen).
-- `src/config/config.ts` erstellen und `dotenv` einbinden.
-- Konfigurationsobjekt mit typisierten Environment-Variablen exportieren.
-- Beim Server-Start auf notwendige Variablen prüfen.
+- Dependencies `pg` und `knex` installieren.
+- Dev-Dependency `@types/pg` installieren.
+- `src/database/connection.ts` mit Knex-Konfiguration basierend auf `config.databaseUrl` erstellen.
+- Knex-Instanz exportieren und `testConnection()` Funktion implementieren.
+- Verzeichnis `src/database/migrations/` anlegen.
 
 ### Validierung
 - `npx tsc --noEmit`
-- `npx ts-node src/index.ts` starten und auf erfolgreiche Initialisierung prüfen.
+- `npx ts-node src/database/connection.ts` ausführen und erfolgreiche Verbindung prüfen.
 
 ### Selbstgenerierung
 - Nach Abschluss dieses Schrittes automatisch den nächsten Prompt in `/codex/daten/prompt.md` schreiben.

--- a/codex/daten/roadmap.md
+++ b/codex/daten/roadmap.md
@@ -63,7 +63,7 @@ Details: Navigiere in `backend/` Ordner. Führe `npm init -y` aus. Installiere D
 [x] Express Server Basis-Konfiguration:
 Details: In `src/index.ts`, importiere required modules: `express`, `cors`, `helmet`, `morgan`. Erstelle Express-App-Instanz: `const app = express()`. Konfiguriere Middleware: `app.use(cors())`, `app.use(helmet())`, `app.use(morgan('combined'))`, `app.use(express.json())`. Definiere Port: `const PORT = process.env.PORT || 3000`. Starte Server mit `app.listen(PORT, callback)`. Erstelle Health-Check-Endpoint: `app.get('/health', handler)`.
 
-[ ] Environment Variables Setup:
+[x] Environment Variables Setup:
 Details: Erstelle `.env.example` mit required Variables: `DATABASE_URL`, `JWT_SECRET`, `JWT_REFRESH_SECRET`, `EMAIL_SERVICE_KEY`, `NODE_ENV`. Erstelle `.env` Datei basierend auf Example. In `src/config/config.ts`, implementiere Configuration-Object mit `dotenv` import. Exportiere typed Configuration-Interface mit allen Environment-Variables. Validiere required Variables beim Server-Start.
 
 [ ] Database Connection Setup mit PostgreSQL:


### PR DESCRIPTION
## Summary
- add example env file and configuration loader for backend
- ignore environment files and load config in server startup
- update roadmap, changelog and next-step prompt

## Testing
- `npx tsc --noEmit`
- `npx ts-node src/index.ts`


------
https://chatgpt.com/codex/tasks/task_e_689530c50bb8832eb0d5e82ad73e70e6