### PR TITLE
feat: add PostgreSQL connection setup

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -18,7 +18,9 @@
     "express-validator": "^7.2.1",
     "helmet": "^8.1.0",
     "jsonwebtoken": "^9.0.2",
-    "morgan": "^1.10.1"
+    "morgan": "^1.10.1",
+    "knex": "^3.1.0",
+    "pg": "^8.11.5"
   },
   "devDependencies": {
     "@types/cors": "^2.8.19",
@@ -27,6 +29,7 @@
     "@types/node": "^24.2.0",
     "nodemon": "^3.1.10",
     "ts-node": "^10.9.2",
-    "typescript": "^5.9.2"
+    "typescript": "^5.9.2",
+    "@types/pg": "^8.11.6"
   }
 }

--- a/backend/src/database/connection.ts
+++ b/backend/src/database/connection.ts
@@ -1,0 +1,28 @@
+import knex, { Knex } from 'knex';
+import { config } from '../config/config';
+
+const knexConfig: Knex.Config = {
+  client: 'pg',
+  connection: config.databaseUrl,
+  pool: { min: 0, max: 10 },
+};
+
+export const db = knex(knexConfig);
+
+export async function testConnection(): Promise<void> {
+  try {
+    await db.raw('select 1+1 as result');
+    console.log('Database connection successful');
+  } catch (error) {
+    console.error('Database connection failed', error);
+    throw error;
+  } finally {
+    await db.destroy();
+  }
+}
+
+if (require.main === module) {
+  testConnection()
+    .then(() => process.exit(0))
+    .catch(() => process.exit(1));
+}

--- a/codex/daten/changelog.md
+++ b/codex/daten/changelog.md
@@ -75,3 +75,8 @@
 - `src/config/config.ts` hinzugefügt und Variablenvalidierung implementiert
 - `.gitignore` erweitert, um `.env`-Dateien auszuschließen
 - `src/index.ts` lädt Konfiguration und protokolliert aktuelles Environment
+
+### Phase 1: Database Connection Setup mit PostgreSQL - 2025-08-07
+- Dependencies `pg` und `knex` sowie Dev-Dependency `@types/pg` hinzugefügt
+- `src/database/connection.ts` mit Knex-Konfiguration und `testConnection()` erstellt
+- Verzeichnis `src/database/migrations/` angelegt

--- a/codex/daten/prompt.md
+++ b/codex/daten/prompt.md
@@ -1,4 +1,4 @@
-# Nächster Schritt: Phase 1 – `Database Connection Setup mit PostgreSQL`
+# Nächster Schritt: Phase 1 – `User-Tabelle Migration erstellen`
 
 ## Status
 - Phase 0 abgeschlossen ✓
@@ -17,6 +17,7 @@
 - Node.js Express Server initialisiert ✓
 - Express Server Basis-Konfiguration implementiert ✓
 - Environment Variables Setup implementiert ✓
+- Database Connection Setup mit PostgreSQL ✓
 
 ## Referenzen
 - `/README.md`
@@ -24,24 +25,23 @@
 - `/codex/daten/roadmap.md`
 - `/codex/daten/changelog.md`
 
-## Nächste Aufgabe: `Database Connection Setup mit PostgreSQL`
+## Nächste Aufgabe: `User-Tabelle Migration erstellen`
 
 ### Vorbereitungen
 - Navigiere zum Projekt-Root `backend/`.
 
 ### Implementierungsschritte
-- Dependencies `pg` und `knex` installieren.
-- Dev-Dependency `@types/pg` installieren.
-- `src/database/connection.ts` mit Knex-Konfiguration basierend auf `config.databaseUrl` erstellen.
-- Knex-Instanz exportieren und `testConnection()` Funktion implementieren.
-- Verzeichnis `src/database/migrations/` anlegen.
+- `npx knex migrate:make create_users_table` ausführen.
+- In der generierten Migration `users` Tabelle mit Spalten `id`, `name`, `email`, `password`, `created_at`, `updated_at` erstellen.
+- `email` als einzigartigen Index definieren.
+- In `down()` die Tabelle wieder entfernen.
 
 ### Validierung
-- `npx tsc --noEmit`
-- `npx ts-node src/database/connection.ts` ausführen und erfolgreiche Verbindung prüfen.
+- `npx tsc --noEmit`.
+- `npx knex migrate:latest` (führt Migration aus).
+- `npx knex migrate:rollback` (setzt Migration zurück).
 
 ### Selbstgenerierung
 - Nach Abschluss dieses Schrittes automatisch den nächsten Prompt in `/codex/daten/prompt.md` schreiben.
 
 *Hinweis: Codex kann keine Binärdateien mergen. Benötigte Dateien müssen durch Skripte generiert werden. Halte den Codeumfang dieses Sprints unter 500 Zeilen.*
-

--- a/codex/daten/roadmap.md
+++ b/codex/daten/roadmap.md
@@ -66,7 +66,7 @@ Details: In `src/index.ts`, importiere required modules: `express`, `cors`, `hel
 [x] Environment Variables Setup:
 Details: Erstelle `.env.example` mit required Variables: `DATABASE_URL`, `JWT_SECRET`, `JWT_REFRESH_SECRET`, `EMAIL_SERVICE_KEY`, `NODE_ENV`. Erstelle `.env` Datei basierend auf Example. In `src/config/config.ts`, implementiere Configuration-Object mit `dotenv` import. Exportiere typed Configuration-Interface mit allen Environment-Variables. Validiere required Variables beim Server-Start.
 
-[ ] Database Connection Setup mit PostgreSQL:
+[x] Database Connection Setup mit PostgreSQL:
 Details: Installiere PostgreSQL-Dependencies: `npm install pg knex`. Installiere Types: `npm install --save-dev @types/pg`. Erstelle `src/database/connection.ts` mit Knex-Konfiguration. Definiere Database-Config-Object mit Connection-String aus Environment. Exportiere Knex-Instanz. Erstelle `src/database/migrations/` Ordner für Schema-Migrations. Implementiere Connection-Test-Funktion.
 
 [ ] User-Tabelle Migration erstellen:


### PR DESCRIPTION
## Summary
- install pg/knex and wire up Knex connection with test helper
- add placeholder migrations folder
- document progress and next steps in roadmap, changelog and prompt

## Testing
- `npm install --no-audit --no-fund`
- `npx tsc --noEmit`
- `DATABASE_URL=postgres://user:password@localhost:5432/mrs_unkwn JWT_SECRET=secret JWT_REFRESH_SECRET=secret2 EMAIL_SERVICE_KEY=key NODE_ENV=development npx ts-node src/database/connection.ts` *(fails: connect ECONNREFUSED)*

------
https://chatgpt.com/codex/tasks/task_e_689534c0a334832ea96e8f209613ef7a