### PR TITLE
Add family tables migration

### DIFF
--- a/backend/src/database/migrations/20250807235713_create_families_table.ts
+++ b/backend/src/database/migrations/20250807235713_create_families_table.ts
@@ -1,0 +1,44 @@
+import type { Knex } from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.schema.createTable('families', (table) => {
+    table.uuid('id').primary();
+    table.string('name').notNullable();
+    table
+      .uuid('created_by')
+      .notNullable()
+      .references('id')
+      .inTable('users')
+      .onDelete('CASCADE');
+    table.string('subscription_tier').notNullable();
+    table.timestamps(true, true);
+  });
+
+  await knex.schema.createTable('family_members', (table) => {
+    table.uuid('id').primary();
+    table
+      .uuid('family_id')
+      .notNullable()
+      .references('id')
+      .inTable('families')
+      .onDelete('CASCADE')
+      .index();
+    table
+      .uuid('user_id')
+      .notNullable()
+      .references('id')
+      .inTable('users')
+      .onDelete('CASCADE')
+      .index();
+    table.string('role').notNullable();
+    table.jsonb('permissions');
+    table.timestamp('joined_at').defaultTo(knex.fn.now());
+    table.unique(['family_id', 'user_id']);
+  });
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.dropTableIfExists('family_members');
+  await knex.schema.dropTableIfExists('families');
+}
+

--- a/codex/daten/changelog.md
+++ b/codex/daten/changelog.md
@@ -85,3 +85,8 @@
 - `knexfile.ts` für Migrationskonfiguration hinzugefügt
 - Migration zur Erstellung der `users` Tabelle mit UUID, Namen, E-Mail, Passwort-Hash und Rollenfeldern erstellt
 - `knex migrate:latest` und `knex migrate:rollback` erfolgreich ausgeführt
+
+### Phase 1: Family-Tabellen Migration erstellen - 2025-08-07
+- Migration für `families` und `family_members` Tabellen implementiert
+- Spalten, Fremdschlüssel-Constraints und Indexe hinzugefügt
+- `knex migrate:latest` und `knex migrate:rollback` ausgeführt (fehlgeschlagen: Unable to acquire a connection)

--- a/codex/daten/prompt.md
+++ b/codex/daten/prompt.md
@@ -1,4 +1,4 @@
-# Nächster Schritt: Phase 1 – `Family-Tabellen Migration erstellen`
+# Nächster Schritt: Phase 1 – `JWT Authentication Service implementieren`
 
 ## Status
 - Phase 0 abgeschlossen ✓
@@ -19,6 +19,7 @@
 - Environment Variables Setup implementiert ✓
 - Database Connection Setup mit PostgreSQL ✓
 - User-Tabelle Migration erstellt ✓
+- Family-Tabellen Migration erstellt ✓
 
 ## Referenzen
 - `/README.md`
@@ -26,22 +27,21 @@
 - `/codex/daten/roadmap.md`
 - `/codex/daten/changelog.md`
 
-## Nächste Aufgabe: `Family-Tabellen Migration erstellen`
+## Nächste Aufgabe: `JWT Authentication Service implementieren`
 
 ### Vorbereitungen
 - Navigiere zum Projekt-Root `backend/`.
 
 ### Implementierungsschritte
-- `npx knex migrate:make create_families_table` ausführen.
-- In der Migration `families` Tabelle mit Spalten `id`, `name`, `created_by`, `subscription_tier`, `created_at`, `updated_at` erstellen.
-- `family_members` Tabelle mit Spalten `id`, `family_id`, `user_id`, `role`, `permissions`, `joined_at` erstellen.
-- Fremdschlüssel-Constraints und Indexe für Relationen setzen.
-- In `down()` beide Tabellen wieder entfernen.
+- `src/services/auth.service.ts` erstellen.
+- `AuthService` Klasse mit Methoden `generateTokens(userId: string)`, `verifyAccessToken(token: string)`, `verifyRefreshToken(token: string)`, `refreshTokens(refreshToken: string)` implementieren.
+- `jsonwebtoken` für Token-Erstellung und -Validierung verwenden.
+- Ablaufzeiten: Access-Token 15 Minuten, Refresh-Token 7 Tage.
+- Token-Blacklisting-Logik vorbereiten.
 
 ### Validierung
 - `npx tsc --noEmit`.
-- `npx knex migrate:latest` (führt Migration aus).
-- `npx knex migrate:rollback` (setzt Migration zurück).
+- `npm test` (falls Tests vorhanden).
 
 ### Selbstgenerierung
 - Nach Abschluss dieses Schrittes automatisch den nächsten Prompt in `/codex/daten/prompt.md` schreiben.

--- a/codex/daten/roadmap.md
+++ b/codex/daten/roadmap.md
@@ -72,7 +72,7 @@ Details: Installiere PostgreSQL-Dependencies: `npm install pg knex`. Installiere
 [x] User-Tabelle Migration erstellen:
 Details: Führe `npx knex migrate:make create_users_table` aus. In der generierten Migration-Datei, implementiere `up()` Funktion: erstelle `users` Tabelle mit Spalten `id` (UUID, primary), `email` (string, unique), `password_hash` (string), `first_name` (string), `last_name` (string), `role` (enum: parent/child), `created_at` (timestamp), `updated_at` (timestamp). Implementiere `down()` Funktion zum Löschen der Tabelle.
 
-[ ] Family-Tabellen Migration erstellen:
+[x] Family-Tabellen Migration erstellen:
 Details: Erstelle Migration für `families` Tabelle: `id` (UUID), `name` (string), `created_by` (UUID, foreign key zu users), `subscription_tier` (string), `created_at`, `updated_at`. Erstelle `family_members` Junction-Tabelle: `id` (UUID), `family_id` (UUID, foreign key), `user_id` (UUID, foreign key), `role` (string), `permissions` (JSON), `joined_at` (timestamp). Definiere Foreign-Key-Constraints und Indexes.
 
 [ ] JWT Authentication Service implementieren:


### PR DESCRIPTION
## Summary
- add Knex migration for families and family_members tables with relations to users
- record completion in roadmap, changelog, and prompt

## Testing
- `npx tsc --noEmit`
- `npx knex migrate:latest` *(fails: Unable to acquire a connection)*
- `npx knex migrate:rollback` *(fails: Unable to acquire a connection)*

------
https://chatgpt.com/codex/tasks/task_e_68953cb8737c832e9c3170ab91c56153