### PR TITLE
feat: implement JWT auth service

### DIFF
--- a/backend/src/services/auth.service.ts
+++ b/backend/src/services/auth.service.ts
@@ -1,0 +1,53 @@
+import jwt from 'jsonwebtoken';
+import { config } from '../config/config';
+
+export interface TokenPair {
+  accessToken: string;
+  refreshToken: string;
+}
+
+interface TokenPayload {
+  userId: string;
+  iat?: number;
+  exp?: number;
+}
+
+class AuthService {
+  private blacklistedTokens = new Set<string>();
+
+  generateTokens(userId: string): TokenPair {
+    const accessToken = jwt.sign({ userId }, config.jwtSecret, { expiresIn: '15m' });
+    const refreshToken = jwt.sign({ userId }, config.jwtRefreshSecret, { expiresIn: '7d' });
+    return { accessToken, refreshToken };
+  }
+
+  verifyAccessToken(token: string): TokenPayload {
+    if (this.isTokenBlacklisted(token)) {
+      throw new Error('Token blacklisted');
+    }
+    return jwt.verify(token, config.jwtSecret) as TokenPayload;
+  }
+
+  verifyRefreshToken(token: string): TokenPayload {
+    if (this.isTokenBlacklisted(token)) {
+      throw new Error('Token blacklisted');
+    }
+    return jwt.verify(token, config.jwtRefreshSecret) as TokenPayload;
+  }
+
+  refreshTokens(refreshToken: string): TokenPair {
+    const payload = this.verifyRefreshToken(refreshToken);
+    this.blacklistToken(refreshToken);
+    return this.generateTokens(payload.userId);
+  }
+
+  blacklistToken(token: string): void {
+    this.blacklistedTokens.add(token);
+  }
+
+  isTokenBlacklisted(token: string): boolean {
+    return this.blacklistedTokens.has(token);
+  }
+}
+
+export const authService = new AuthService();

--- a/backend/src/types.d.ts
+++ b/backend/src/types.d.ts
@@ -1,2 +1,3 @@
 declare module 'cors';
 declare module 'morgan';
+declare module 'jsonwebtoken';

--- a/codex/daten/changelog.md
+++ b/codex/daten/changelog.md
@@ -90,3 +90,8 @@
 - Migration für `families` und `family_members` Tabellen implementiert
 - Spalten, Fremdschlüssel-Constraints und Indexe hinzugefügt
 - `knex migrate:latest` und `knex migrate:rollback` ausgeführt (fehlgeschlagen: Unable to acquire a connection)
+
+### Phase 1: JWT Authentication Service implementieren - 2025-08-08
+- `AuthService` mit Token-Erstellung, Verifikation, Refresh und Blacklisting erstellt
+- `types.d.ts` um Deklaration für `jsonwebtoken` erweitert
+- Roadmap aktualisiert

--- a/codex/daten/prompt.md
+++ b/codex/daten/prompt.md
@@ -1,4 +1,4 @@
-# Nächster Schritt: Phase 1 – `JWT Authentication Service implementieren`
+# Nächster Schritt: Phase 1 – `Password Hashing Service`
 
 ## Status
 - Phase 0 abgeschlossen ✓
@@ -20,6 +20,7 @@
 - Database Connection Setup mit PostgreSQL ✓
 - User-Tabelle Migration erstellt ✓
 - Family-Tabellen Migration erstellt ✓
+- JWT Authentication Service implementiert ✓
 
 ## Referenzen
 - `/README.md`
@@ -27,17 +28,16 @@
 - `/codex/daten/roadmap.md`
 - `/codex/daten/changelog.md`
 
-## Nächste Aufgabe: `JWT Authentication Service implementieren`
+## Nächste Aufgabe: `Password Hashing Service`
 
 ### Vorbereitungen
 - Navigiere zum Projekt-Root `backend/`.
 
 ### Implementierungsschritte
-- `src/services/auth.service.ts` erstellen.
-- `AuthService` Klasse mit Methoden `generateTokens(userId: string)`, `verifyAccessToken(token: string)`, `verifyRefreshToken(token: string)`, `refreshTokens(refreshToken: string)` implementieren.
-- `jsonwebtoken` für Token-Erstellung und -Validierung verwenden.
-- Ablaufzeiten: Access-Token 15 Minuten, Refresh-Token 7 Tage.
-- Token-Blacklisting-Logik vorbereiten.
+- `src/services/password.service.ts` erstellen.
+- `PasswordService` mit statischen Methoden `hashPassword(password: string): Promise<string>` und `comparePassword(password: string, hash: string): Promise<boolean>` implementieren.
+- `bcrypt` verwenden mit 12 Runden.
+- Passwort-Strength-Validation: mindestens 8 Zeichen, je 1 Großbuchstabe, Kleinbuchstabe, Zahl und Sonderzeichen.
 
 ### Validierung
 - `npx tsc --noEmit`.

--- a/codex/daten/roadmap.md
+++ b/codex/daten/roadmap.md
@@ -75,7 +75,7 @@ Details: Führe `npx knex migrate:make create_users_table` aus. In der generiert
 [x] Family-Tabellen Migration erstellen:
 Details: Erstelle Migration für `families` Tabelle: `id` (UUID), `name` (string), `created_by` (UUID, foreign key zu users), `subscription_tier` (string), `created_at`, `updated_at`. Erstelle `family_members` Junction-Tabelle: `id` (UUID), `family_id` (UUID, foreign key), `user_id` (UUID, foreign key), `role` (string), `permissions` (JSON), `joined_at` (timestamp). Definiere Foreign-Key-Constraints und Indexes.
 
-[ ] JWT Authentication Service implementieren:
+[x] JWT Authentication Service implementieren:
 Details: Erstelle `src/services/auth.service.ts`. Implementiere `AuthService` Klasse mit Methoden: `generateTokens(userId: string)`, `verifyAccessToken(token: string)`, `verifyRefreshToken(token: string)`, `refreshTokens(refreshToken: string)`. Verwende `jsonwebtoken` Library. Konfiguriere Token-Expiry: Access-Token 15min, Refresh-Token 7 Tage. Implementiere Token-Blacklisting-Logic.
 
 [ ] Password Hashing Service:


### PR DESCRIPTION
## Summary
- add AuthService for JWT generation, verification, refreshing and blacklist handling
- declare jsonwebtoken module for TypeScript
- document completion and update roadmap and next prompt

## Testing
- `npx tsc --noEmit`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689540b46004832ea96c7d22d105b6b2