### PR TITLE
feat: add password hashing service

### DIFF
--- a/backend/src/services/password.service.ts
+++ b/backend/src/services/password.service.ts
@@ -1,0 +1,21 @@
+import bcrypt from 'bcrypt';
+
+const SALT_ROUNDS = 12;
+const PASSWORD_REGEX = /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[^\w\s]).{8,}$/;
+
+export class PasswordService {
+  static validate(password: string): boolean {
+    return PASSWORD_REGEX.test(password);
+  }
+
+  static async hashPassword(password: string): Promise<string> {
+    if (!this.validate(password)) {
+      throw new Error('Password does not meet strength requirements');
+    }
+    return bcrypt.hash(password, SALT_ROUNDS);
+  }
+
+  static async comparePassword(password: string, hash: string): Promise<boolean> {
+    return bcrypt.compare(password, hash);
+  }
+}

--- a/backend/src/types.d.ts
+++ b/backend/src/types.d.ts
@@ -1,3 +1,4 @@
 declare module 'cors';
 declare module 'morgan';
 declare module 'jsonwebtoken';
+declare module 'bcrypt';

--- a/codex/daten/changelog.md
+++ b/codex/daten/changelog.md
@@ -95,3 +95,7 @@
 - `AuthService` mit Token-Erstellung, Verifikation, Refresh und Blacklisting erstellt
 - `types.d.ts` um Deklaration für `jsonwebtoken` erweitert
 - Roadmap aktualisiert
+
+### Phase 1: Password Hashing Service implementieren - 2025-08-08
+- `PasswordService` mit bcrypt Hashing, Passwort-Validierung und Vergleichsfunktion hinzugefügt
+- Roadmap aktualisiert

--- a/codex/daten/prompt.md
+++ b/codex/daten/prompt.md
@@ -1,4 +1,4 @@
-# Nächster Schritt: Phase 1 – `Password Hashing Service`
+# Nächster Schritt: Phase 1 – `User Repository Pattern`
 
 ## Status
 - Phase 0 abgeschlossen ✓
@@ -21,6 +21,7 @@
 - User-Tabelle Migration erstellt ✓
 - Family-Tabellen Migration erstellt ✓
 - JWT Authentication Service implementiert ✓
+- Password Hashing Service implementiert ✓
 
 ## Referenzen
 - `/README.md`
@@ -28,16 +29,15 @@
 - `/codex/daten/roadmap.md`
 - `/codex/daten/changelog.md`
 
-## Nächste Aufgabe: `Password Hashing Service`
+## Nächste Aufgabe: `User Repository Pattern`
 
 ### Vorbereitungen
 - Navigiere zum Projekt-Root `backend/`.
 
 ### Implementierungsschritte
-- `src/services/password.service.ts` erstellen.
-- `PasswordService` mit statischen Methoden `hashPassword(password: string): Promise<string>` und `comparePassword(password: string, hash: string): Promise<boolean>` implementieren.
-- `bcrypt` verwenden mit 12 Runden.
-- Passwort-Strength-Validation: mindestens 8 Zeichen, je 1 Großbuchstabe, Kleinbuchstabe, Zahl und Sonderzeichen.
+- `src/repositories/user.repository.ts` erstellen.
+- `UserRepository` Klasse mit Methoden `create`, `findByEmail`, `findById`, `update`, `delete` implementieren.
+- Knex Query-Builder verwenden.
 
 ### Validierung
 - `npx tsc --noEmit`.

--- a/codex/daten/roadmap.md
+++ b/codex/daten/roadmap.md
@@ -78,7 +78,7 @@ Details: Erstelle Migration für `families` Tabelle: `id` (UUID), `name` (string
 [x] JWT Authentication Service implementieren:
 Details: Erstelle `src/services/auth.service.ts`. Implementiere `AuthService` Klasse mit Methoden: `generateTokens(userId: string)`, `verifyAccessToken(token: string)`, `verifyRefreshToken(token: string)`, `refreshTokens(refreshToken: string)`. Verwende `jsonwebtoken` Library. Konfiguriere Token-Expiry: Access-Token 15min, Refresh-Token 7 Tage. Implementiere Token-Blacklisting-Logic.
 
-[ ] Password Hashing Service:
+[x] Password Hashing Service:
 Details: Erstelle `src/services/password.service.ts`. Implementiere `PasswordService` mit static methods: `async hashPassword(password: string): Promise<string>` mit `bcrypt.hash()` und salt-rounds 12. Implementiere `async comparePassword(password: string, hash: string): Promise<boolean>` mit `bcrypt.compare()`. Füge Password-Strength-Validation hinzu: mindestens 8 Zeichen, 1 Uppercase, 1 Lowercase, 1 Number, 1 Special-Character.
 
 [ ] User Repository Pattern implementieren:


### PR DESCRIPTION
## Summary
- add PasswordService with bcrypt hashing and strength validation
- declare bcrypt module types for TypeScript
- document progress and update roadmap and prompt

## Testing
- `npx tsc --noEmit`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689544b0fa8c832e982f1746722d7c42