### PR TITLE
Add request validation middleware and schemas

### DIFF
--- a/backend/src/middleware/validation.middleware.ts
+++ b/backend/src/middleware/validation.middleware.ts
@@ -1,0 +1,33 @@
+import { Request, Response, NextFunction } from 'express';
+import { ValidationChain, validationResult } from 'express-validator';
+
+interface ValidationErrorItem {
+  field: string;
+  message: string;
+}
+
+interface ValidationErrorResponse {
+  errors: ValidationErrorItem[];
+}
+
+export const validateRequest = (validations: ValidationChain[]) => {
+  return async (req: Request, res: Response, next: NextFunction) => {
+    for (const validation of validations) {
+      await validation.run(req);
+    }
+
+    const errors = validationResult(req);
+    if (errors.isEmpty()) {
+      return next();
+    }
+
+    const formatted: ValidationErrorResponse = {
+      errors: errors.array().map(err => ({
+        field: 'path' in err ? err.path : err.type,
+        message: err.msg,
+      })),
+    };
+
+    return res.status(400).json(formatted);
+  };
+};

--- a/backend/src/validation/schemas/userLogin.schema.ts
+++ b/backend/src/validation/schemas/userLogin.schema.ts
@@ -1,0 +1,10 @@
+import { body } from 'express-validator';
+
+export const userLoginSchema = [
+  body('email')
+    .isEmail()
+    .withMessage('Valid email is required'),
+  body('password')
+    .notEmpty()
+    .withMessage('Password is required'),
+];

--- a/backend/src/validation/schemas/userRegistration.schema.ts
+++ b/backend/src/validation/schemas/userRegistration.schema.ts
@@ -1,0 +1,20 @@
+import { body } from 'express-validator';
+
+export const userRegistrationSchema = [
+  body('name')
+    .trim()
+    .notEmpty()
+    .withMessage('Name is required'),
+  body('email')
+    .isEmail()
+    .withMessage('Valid email is required'),
+  body('password')
+    .isStrongPassword({
+      minLength: 8,
+      minLowercase: 1,
+      minUppercase: 1,
+      minNumbers: 1,
+      minSymbols: 1,
+    })
+    .withMessage('Password must be at least 8 characters long and include uppercase, lowercase, number and symbol'),
+];

--- a/codex/daten/changelog.md
+++ b/codex/daten/changelog.md
@@ -104,3 +104,8 @@
 - `UserRepository` in `backend/src/repositories/user.repository.ts` erstellt
 - CRUD-Methoden (`create`, `findByEmail`, `findById`, `update`, `delete`) mit Knex umgesetzt
 - Roadmap aktualisiert
+
+### Phase 1: Request Validation Middleware - 2025-08-08
+- `validateRequest` Middleware mit feldspezifischem Fehlerformat erstellt
+- Validierungsschemas für Registrierung und Login hinzugefügt
+- Roadmap aktualisiert

--- a/codex/daten/prompt.md
+++ b/codex/daten/prompt.md
@@ -1,4 +1,4 @@
-# Nächster Schritt: Phase 1 – `Request Validation Middleware`
+# Nächster Schritt: Phase 1 – `Authentication Middleware`
 
 ## Status
 - Phase 0 abgeschlossen ✓
@@ -23,6 +23,7 @@
 - JWT Authentication Service implementiert ✓
 - Password Hashing Service implementiert ✓
 - User Repository Pattern implementiert ✓
+- Request Validation Middleware implementiert ✓
 
 ## Referenzen
 - `/README.md`
@@ -30,17 +31,17 @@
 - `/codex/daten/roadmap.md`
 - `/codex/daten/changelog.md`
 
-## Nächste Aufgabe: `Request Validation Middleware`
+## Nächste Aufgabe: `Authentication Middleware`
 
 ### Vorbereitungen
 - Navigiere zum Projekt-Root `backend/`.
 
 ### Implementierungsschritte
-- `src/middleware/validation.middleware.ts` erstellen.
-- `validateRequest` Higher-Order-Function implementieren, die express-validator Rules akzeptiert.
-- Validation-Schemas in `src/validation/schemas/` anlegen: `userRegistration.schema.ts`, `userLogin.schema.ts`.
-- Jedes Schema definiert Validation-Rules für Request-Body-Fields.
-- Error-Response-Format mit Field-specific-Messages bei Validation-Failures implementieren.
+- `src/middleware/auth.middleware.ts` erstellen.
+- `authenticateToken` Middleware-Funktion implementieren, die Authorization-Header prüft, JWT-Token extrahiert und verifiziert.
+- Bei gültigem Token User-Daten zu `req.user` hinzufügen.
+- `authorizeRoles(...roles)` Middleware für Role-based-Access-Control implementieren.
+- `optionalAuth` Middleware für Endpoints hinzufügen, die sowohl Auth als auch Non-Auth-Requests akzeptieren.
 
 ### Validierung
 - `npx tsc --noEmit`.

--- a/codex/daten/roadmap.md
+++ b/codex/daten/roadmap.md
@@ -84,7 +84,7 @@ Details: Erstelle `src/services/password.service.ts`. Implementiere `PasswordSer
 [x] User Repository Pattern implementieren:
 Details: Erstelle `src/repositories/user.repository.ts`. Implementiere `UserRepository` Klasse mit Database-Abstraction-Layer. Methoden: `async create(userData: CreateUserDTO): Promise<User>`, `async findByEmail(email: string): Promise<User | null>`, `async findById(id: string): Promise<User | null>`, `async update(id: string, data: UpdateUserDTO): Promise<User>`, `async delete(id: string): Promise<void>`. Verwende Knex Query-Builder.
 
-[ ] Request Validation Middleware:
+[x] Request Validation Middleware:
 Details: Erstelle `src/middleware/validation.middleware.ts`. Implementiere `validateRequest` Higher-Order-Function die express-validator Rules akzeptiert. Erstelle Validation-Schemas in `src/validation/schemas/`: `userRegistration.schema.ts`, `userLogin.schema.ts`. Jedes Schema definiert Validation-Rules für Request-Body-Fields. Implementiere Error-Response-Format für Validation-Failures mit Field-specific-Messages.
 
 [ ] Authentication Middleware implementieren:


### PR DESCRIPTION
## Summary
- add `validateRequest` middleware for Express with field-based error formatting
- define user registration and login validation schemas
- update roadmap, changelog, and next development prompt

## Testing
- `npx tsc --noEmit`
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68954ca923d8832ebdcf6b3baca4d31d