### PR TITLE
feat: add authentication middleware

### DIFF
--- a/backend/src/express.d.ts
+++ b/backend/src/express.d.ts
@@ -1,0 +1,11 @@
+import { User } from './repositories/user.repository';
+
+declare global {
+  namespace Express {
+    interface Request {
+      user?: User;
+    }
+  }
+}
+
+export {};

--- a/backend/src/middleware/auth.middleware.ts
+++ b/backend/src/middleware/auth.middleware.ts
@@ -1,0 +1,66 @@
+import { Request, Response, NextFunction } from 'express';
+import { authService } from '../services/auth.service';
+import { userRepository, User } from '../repositories/user.repository';
+
+const extractToken = (header?: string) =>
+  header?.startsWith('Bearer ') ? header.split(' ')[1] : undefined;
+
+export const authenticateToken = async (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): Promise<void> => {
+  const token = extractToken(req.headers['authorization']);
+  if (!token) {
+    res.status(401).json({ message: 'Unauthorized' });
+    return;
+  }
+
+  try {
+    const payload = authService.verifyAccessToken(token);
+    const user = await userRepository.findById(payload.userId);
+    if (!user) {
+      res.status(401).json({ message: 'Unauthorized' });
+      return;
+    }
+    req.user = user;
+    next();
+  } catch {
+    res.status(401).json({ message: 'Unauthorized' });
+  }
+};
+
+export const authorizeRoles = (
+  ...roles: User['role'][]
+) => {
+  return (req: Request, res: Response, next: NextFunction): void => {
+    if (!req.user || !roles.includes(req.user.role)) {
+      res.status(403).json({ message: 'Forbidden' });
+      return;
+    }
+    next();
+  };
+};
+
+export const optionalAuth = async (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): Promise<void> => {
+  const token = extractToken(req.headers['authorization']);
+  if (!token) {
+    next();
+    return;
+  }
+
+  try {
+    const payload = authService.verifyAccessToken(token);
+    const user = await userRepository.findById(payload.userId);
+    if (user) {
+      req.user = user;
+    }
+    next();
+  } catch {
+    res.status(401).json({ message: 'Unauthorized' });
+  }
+};

--- a/codex/daten/changelog.md
+++ b/codex/daten/changelog.md
@@ -109,3 +109,8 @@
 - `validateRequest` Middleware mit feldspezifischem Fehlerformat erstellt
 - Validierungsschemas für Registrierung und Login hinzugefügt
 - Roadmap aktualisiert
+
+### Phase 1: Authentication Middleware implementiert - 2025-08-08
+- `auth.middleware.ts` mit Token-Verifizierung, Rollen- und Optional-Auth-Funktionen erstellt
+- Express `Request` Typ um `user` Feld erweitert
+- Roadmap aktualisiert

--- a/codex/daten/prompt.md
+++ b/codex/daten/prompt.md
@@ -1,4 +1,4 @@
-# Nächster Schritt: Phase 1 – `Authentication Middleware`
+# Nächster Schritt: Phase 1 – `Basic API Routes Setup`
 
 ## Status
 - Phase 0 abgeschlossen ✓
@@ -24,6 +24,7 @@
 - Password Hashing Service implementiert ✓
 - User Repository Pattern implementiert ✓
 - Request Validation Middleware implementiert ✓
+- Authentication Middleware implementiert ✓
 
 ## Referenzen
 - `/README.md`
@@ -31,17 +32,17 @@
 - `/codex/daten/roadmap.md`
 - `/codex/daten/changelog.md`
 
-## Nächste Aufgabe: `Authentication Middleware`
+## Nächste Aufgabe: `Basic API Routes Setup`
 
 ### Vorbereitungen
 - Navigiere zum Projekt-Root `backend/`.
 
 ### Implementierungsschritte
-- `src/middleware/auth.middleware.ts` erstellen.
-- `authenticateToken` Middleware-Funktion implementieren, die Authorization-Header prüft, JWT-Token extrahiert und verifiziert.
-- Bei gültigem Token User-Daten zu `req.user` hinzufügen.
-- `authorizeRoles(...roles)` Middleware für Role-based-Access-Control implementieren.
-- `optionalAuth` Middleware für Endpoints hinzufügen, die sowohl Auth als auch Non-Auth-Requests akzeptieren.
+- `src/routes/` Ordner erstellen.
+- `auth.routes.ts` mit Express-Router: POST `/register`, POST `/login`, POST `/refresh`, POST `/logout`.
+- `user.routes.ts` erstellen: GET `/profile`, PUT `/profile`, DELETE `/account`.
+- `src/routes/index.ts` als Main-Router implementieren, der alle Feature-Router kombiniert.
+- Main-Router in `src/index.ts` unter `/api` Prefix mounten.
 
 ### Validierung
 - `npx tsc --noEmit`.

--- a/codex/daten/roadmap.md
+++ b/codex/daten/roadmap.md
@@ -87,7 +87,7 @@ Details: Erstelle `src/repositories/user.repository.ts`. Implementiere `UserRepo
 [x] Request Validation Middleware:
 Details: Erstelle `src/middleware/validation.middleware.ts`. Implementiere `validateRequest` Higher-Order-Function die express-validator Rules akzeptiert. Erstelle Validation-Schemas in `src/validation/schemas/`: `userRegistration.schema.ts`, `userLogin.schema.ts`. Jedes Schema definiert Validation-Rules für Request-Body-Fields. Implementiere Error-Response-Format für Validation-Failures mit Field-specific-Messages.
 
-[ ] Authentication Middleware implementieren:
+[x] Authentication Middleware implementieren:
 Details: Erstelle `src/middleware/auth.middleware.ts`. Implementiere `authenticateToken` Middleware-Funktion die Authorization-Header prüft, JWT-Token extrahiert und verifiziert. Bei gültigem Token, füge User-Data zu `req.user` hinzu. Implementiere `authorizeRoles(...roles)` Middleware für Role-based-Access-Control. Erstelle `optionalAuth` Middleware für Endpoints die sowohl Auth als auch Non-Auth-Requests akzeptieren.
 
 [ ] Basic API Routes Setup:


### PR DESCRIPTION
## Summary
- implement authentication middleware with token verification, role-based authorization, and optional auth handling
- extend Express request type to include authenticated user
- update roadmap, changelog, and next development prompt

## Testing
- `npx tsc --noEmit`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689550a4fb34832ea4756c2d30712c1c