### PR TITLE
feat: add basic API routes

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -3,6 +3,7 @@ import cors from 'cors';
 import helmet from 'helmet';
 import morgan from 'morgan';
 import { config } from './config/config';
+import routes from './routes';
 
 const app = express();
 
@@ -10,6 +11,8 @@ app.use(cors());
 app.use(helmet());
 app.use(morgan('combined'));
 app.use(express.json());
+
+app.use('/api', routes);
 
 const PORT = process.env.PORT || 3000;
 

--- a/backend/src/routes/auth.routes.ts
+++ b/backend/src/routes/auth.routes.ts
@@ -1,0 +1,111 @@
+import { Router, Request, Response } from 'express';
+import { randomUUID } from 'crypto';
+import { validateRequest } from '../middleware/validation.middleware';
+import { userRegistrationSchema } from '../validation/schemas/userRegistration.schema';
+import { userLoginSchema } from '../validation/schemas/userLogin.schema';
+import { userRepository } from '../repositories/user.repository';
+import { PasswordService } from '../services/password.service';
+import { authService } from '../services/auth.service';
+
+const router = Router();
+
+interface RegisterBody {
+  name: string;
+  email: string;
+  password: string;
+}
+
+interface LoginBody {
+  email: string;
+  password: string;
+}
+
+router.post(
+  '/register',
+  validateRequest(userRegistrationSchema),
+  async (req: Request<{}, {}, RegisterBody>, res: Response) => {
+    const { name, email, password } = req.body;
+    const existing = await userRepository.findByEmail(email);
+    if (existing) {
+      return res.status(409).json({ message: 'User already exists' });
+    }
+
+    const password_hash = await PasswordService.hashPassword(password);
+    const [first_name, ...rest] = name.split(' ');
+    const last_name = rest.join(' ');
+
+    const user = await userRepository.create({
+      id: randomUUID(),
+      email,
+      password_hash,
+      first_name,
+      last_name,
+      role: 'parent',
+    });
+
+    const tokens = authService.generateTokens(user.id);
+    return res.status(201).json({ tokens });
+  },
+);
+
+router.post(
+  '/login',
+  validateRequest(userLoginSchema),
+  async (req: Request<{}, {}, LoginBody>, res: Response) => {
+    const { email, password } = req.body;
+    const user = await userRepository.findByEmail(email);
+    if (!user) {
+      return res.status(401).json({ message: 'Invalid credentials' });
+    }
+
+    const valid = await PasswordService.comparePassword(password, user.password_hash);
+    if (!valid) {
+      return res.status(401).json({ message: 'Invalid credentials' });
+    }
+
+    const tokens = authService.generateTokens(user.id);
+    return res.json({ tokens });
+  },
+);
+
+interface RefreshBody {
+  refreshToken: string;
+}
+
+router.post(
+  '/refresh',
+  async (req: Request<{}, {}, RefreshBody>, res: Response) => {
+    const { refreshToken } = req.body;
+    if (!refreshToken) {
+      return res.status(400).json({ message: 'Refresh token required' });
+    }
+
+    try {
+      const tokens = authService.refreshTokens(refreshToken);
+      return res.json({ tokens });
+    } catch {
+      return res.status(401).json({ message: 'Invalid token' });
+    }
+  },
+);
+
+interface LogoutBody {
+  refreshToken: string;
+}
+
+router.post(
+  '/logout',
+  async (req: Request<{}, {}, LogoutBody>, res: Response) => {
+    const accessToken = req.headers['authorization']?.split(' ')[1];
+    const { refreshToken } = req.body;
+    if (accessToken) {
+      authService.blacklistToken(accessToken);
+    }
+    if (refreshToken) {
+      authService.blacklistToken(refreshToken);
+    }
+    return res.status(204).send();
+  },
+);
+
+export default router;

--- a/backend/src/routes/index.ts
+++ b/backend/src/routes/index.ts
@@ -1,0 +1,10 @@
+import { Router } from 'express';
+import authRoutes from './auth.routes';
+import userRoutes from './user.routes';
+
+const router = Router();
+
+router.use('/auth', authRoutes);
+router.use('/user', userRoutes);
+
+export default router;

--- a/backend/src/routes/user.routes.ts
+++ b/backend/src/routes/user.routes.ts
@@ -1,0 +1,39 @@
+import { Router, Request, Response } from 'express';
+import { authenticateToken } from '../middleware/auth.middleware';
+import { userRepository } from '../repositories/user.repository';
+
+const router = Router();
+
+router.get('/profile', authenticateToken, (req: Request, res: Response) => {
+  if (!req.user) {
+    return res.status(401).json({ message: 'Unauthorized' });
+  }
+  const { password_hash, ...user } = req.user;
+  return res.json({ user });
+});
+
+router.put('/profile', authenticateToken, async (req: Request, res: Response) => {
+  if (!req.user) {
+    return res.status(401).json({ message: 'Unauthorized' });
+  }
+  const { first_name, last_name } = req.body as {
+    first_name?: string;
+    last_name?: string;
+  };
+  const updated = await userRepository.update(req.user.id, {
+    first_name: first_name ?? req.user.first_name,
+    last_name: last_name ?? req.user.last_name,
+  });
+  const { password_hash, ...user } = updated;
+  return res.json({ user });
+});
+
+router.delete('/account', authenticateToken, async (req: Request, res: Response) => {
+  if (!req.user) {
+    return res.status(401).json({ message: 'Unauthorized' });
+  }
+  await userRepository.delete(req.user.id);
+  return res.status(204).send();
+});
+
+export default router;

--- a/codex/daten/changelog.md
+++ b/codex/daten/changelog.md
@@ -114,3 +114,9 @@
 - `auth.middleware.ts` mit Token-Verifizierung, Rollen- und Optional-Auth-Funktionen erstellt
 - Express `Request` Typ um `user` Feld erweitert
 - Roadmap aktualisiert
+
+### Phase 1: Basic API Routes Setup - 2025-08-08
+- `auth.routes.ts` mit Endpunkten für Registrierung, Login, Token-Refresh und Logout erstellt
+- `user.routes.ts` mit Profilabruf, Profilaktualisierung und Account-Löschung implementiert
+- Haupt-Router `routes/index.ts` hinzugefügt und unter `/api` in `src/index.ts` eingebunden
+- Roadmap aktualisiert

--- a/codex/daten/prompt.md
+++ b/codex/daten/prompt.md
@@ -1,4 +1,4 @@
-# Nächster Schritt: Phase 1 – `Basic API Routes Setup`
+# Nächster Schritt: Phase 1 – `Error Handling Middleware`
 
 ## Status
 - Phase 0 abgeschlossen ✓
@@ -25,6 +25,7 @@
 - User Repository Pattern implementiert ✓
 - Request Validation Middleware implementiert ✓
 - Authentication Middleware implementiert ✓
+- Basic API Routes Setup implementiert ✓
 
 ## Referenzen
 - `/README.md`
@@ -32,17 +33,17 @@
 - `/codex/daten/roadmap.md`
 - `/codex/daten/changelog.md`
 
-## Nächste Aufgabe: `Basic API Routes Setup`
+## Nächste Aufgabe: `Error Handling Middleware`
 
 ### Vorbereitungen
 - Navigiere zum Projekt-Root `backend/`.
 
 ### Implementierungsschritte
-- `src/routes/` Ordner erstellen.
-- `auth.routes.ts` mit Express-Router: POST `/register`, POST `/login`, POST `/refresh`, POST `/logout`.
-- `user.routes.ts` erstellen: GET `/profile`, PUT `/profile`, DELETE `/account`.
-- `src/routes/index.ts` als Main-Router implementieren, der alle Feature-Router kombiniert.
-- Main-Router in `src/index.ts` unter `/api` Prefix mounten.
+- `src/middleware/error.middleware.ts` erstellen.
+- Globale Fehlerbehandlungs-Middleware implementieren, die Validation-, Datenbank- und Authentifizierungsfehler unterscheidet.
+- Einheitliches Fehlerformat `{ error: { message, code, details } }` verwenden.
+- Unterschiedliche Ausgabe für Development vs. Production (Stack-Traces nur in Dev).
+- Middleware in `src/index.ts` registrieren.
 
 ### Validierung
 - `npx tsc --noEmit`.

--- a/codex/daten/roadmap.md
+++ b/codex/daten/roadmap.md
@@ -90,7 +90,7 @@ Details: Erstelle `src/middleware/validation.middleware.ts`. Implementiere `vali
 [x] Authentication Middleware implementieren:
 Details: Erstelle `src/middleware/auth.middleware.ts`. Implementiere `authenticateToken` Middleware-Funktion die Authorization-Header prüft, JWT-Token extrahiert und verifiziert. Bei gültigem Token, füge User-Data zu `req.user` hinzu. Implementiere `authorizeRoles(...roles)` Middleware für Role-based-Access-Control. Erstelle `optionalAuth` Middleware für Endpoints die sowohl Auth als auch Non-Auth-Requests akzeptieren.
 
-[ ] Basic API Routes Setup:
+[x] Basic API Routes Setup:
 Details: Erstelle `src/routes/` Ordner. Implementiere `auth.routes.ts` mit Express-Router: POST `/register`, POST `/login`, POST `/refresh`, POST `/logout`. Erstelle `user.routes.ts`: GET `/profile`, PUT `/profile`, DELETE `/account`. Erstelle `src/routes/index.ts` als Main-Router der alle Feature-Router kombiniert. Mounten Sie Main-Router in `src/index.ts` unter `/api` Prefix.
 
 [ ] Error Handling Middleware:


### PR DESCRIPTION
## Summary
- add Express routers for auth and user endpoints
- mount new routers under `/api`
- document completion in roadmap and changelog

## Testing
- `npx tsc --noEmit`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689554a124c4832e9158f40c0ff7096a