### PR TITLE
feat: standardize API responses

### DIFF
--- a/backend/src/express.d.ts
+++ b/backend/src/express.d.ts
@@ -5,6 +5,20 @@ declare global {
     interface Request {
       user?: User;
     }
+    interface Response {
+      success: (data: unknown, message?: string, statusCode?: number) => void;
+      error: (
+        message: string,
+        statusCode?: number,
+        details?: unknown,
+      ) => void;
+      paginated: (
+        data: unknown,
+        pagination: unknown,
+        message?: string,
+        statusCode?: number,
+      ) => void;
+    }
   }
 }
 

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -5,6 +5,7 @@ import morgan from 'morgan';
 import { config } from './config/config';
 import routes from './routes';
 import { errorHandler } from './middleware/error.middleware';
+import { responseHandler } from './middleware/response.middleware';
 
 const app = express();
 
@@ -12,11 +13,12 @@ app.use(cors());
 app.use(helmet());
 app.use(morgan('combined'));
 app.use(express.json());
+app.use(responseHandler);
 
 app.use('/api', routes);
 
 app.get('/health', (_req, res) => {
-  res.json({ status: 'ok' });
+  res.success({ status: 'ok' }, 'Health check');
 });
 
 app.use(errorHandler);

--- a/backend/src/middleware/auth.middleware.ts
+++ b/backend/src/middleware/auth.middleware.ts
@@ -12,7 +12,7 @@ export const authenticateToken = async (
 ): Promise<void> => {
   const token = extractToken(req.headers['authorization']);
   if (!token) {
-    res.status(401).json({ message: 'Unauthorized' });
+    res.error('Unauthorized', 401);
     return;
   }
 
@@ -20,13 +20,13 @@ export const authenticateToken = async (
     const payload = authService.verifyAccessToken(token);
     const user = await userRepository.findById(payload.userId);
     if (!user) {
-      res.status(401).json({ message: 'Unauthorized' });
+      res.error('Unauthorized', 401);
       return;
     }
     req.user = user;
     next();
   } catch {
-    res.status(401).json({ message: 'Unauthorized' });
+    res.error('Unauthorized', 401);
   }
 };
 
@@ -35,7 +35,7 @@ export const authorizeRoles = (
 ) => {
   return (req: Request, res: Response, next: NextFunction): void => {
     if (!req.user || !roles.includes(req.user.role)) {
-      res.status(403).json({ message: 'Forbidden' });
+      res.error('Forbidden', 403);
       return;
     }
     next();
@@ -61,6 +61,6 @@ export const optionalAuth = async (
     }
     next();
   } catch {
-    res.status(401).json({ message: 'Unauthorized' });
+    res.error('Unauthorized', 401);
   }
 };

--- a/backend/src/middleware/error.middleware.ts
+++ b/backend/src/middleware/error.middleware.ts
@@ -1,5 +1,6 @@
 import { Request, Response, NextFunction } from 'express';
 import { config } from '../config/config';
+import { error as formatError } from '../utils/response.util';
 
 interface AppError extends Error {
   statusCode?: number;
@@ -31,18 +32,17 @@ export const errorHandler = (
       break;
   }
 
-  const errorResponse: Record<string, unknown> = {
-    message: err.message || 'Internal Server Error',
-    code,
-  };
+  const details: Record<string, unknown> = { code };
 
   if (err.details) {
-    errorResponse.details = err.details;
+    details.details = err.details;
   }
 
   if (config.nodeEnv !== 'production' && err.stack) {
-    errorResponse.stack = err.stack;
+    details.stack = err.stack;
   }
 
-  res.status(statusCode).json({ error: errorResponse });
+  res
+    .status(statusCode)
+    .json(formatError(err.message || 'Internal Server Error', statusCode, details));
 };

--- a/backend/src/middleware/response.middleware.ts
+++ b/backend/src/middleware/response.middleware.ts
@@ -1,0 +1,25 @@
+import { Request, Response, NextFunction } from 'express';
+import { success, error, paginated } from '../utils/response.util';
+
+export const responseHandler = (
+  _req: Request,
+  res: Response,
+  next: NextFunction,
+): void => {
+  res.success = (data, message = 'OK', statusCode = 200) => {
+    res.status(statusCode).json(success(data, message, statusCode));
+  };
+
+  res.error = (message, statusCode = 500, details?) => {
+    res.status(statusCode).json(error(message, statusCode, details));
+  };
+
+  res.paginated = (data, pagination, message = 'OK', statusCode = 200) => {
+    res
+      .status(statusCode)
+      .json(paginated(data, pagination, message, statusCode));
+  };
+
+  next();
+};
+

--- a/backend/src/middleware/validation.middleware.ts
+++ b/backend/src/middleware/validation.middleware.ts
@@ -28,6 +28,6 @@ export const validateRequest = (validations: ValidationChain[]) => {
       })),
     };
 
-    return res.status(400).json(formatted);
+    return res.error('Validation failed', 400, formatted);
   };
 };

--- a/backend/src/routes/auth.routes.ts
+++ b/backend/src/routes/auth.routes.ts
@@ -27,7 +27,7 @@ router.post(
     const { name, email, password } = req.body;
     const existing = await userRepository.findByEmail(email);
     if (existing) {
-      return res.status(409).json({ message: 'User already exists' });
+      return res.error('User already exists', 409);
     }
 
     const password_hash = await PasswordService.hashPassword(password);
@@ -44,7 +44,7 @@ router.post(
     });
 
     const tokens = authService.generateTokens(user.id);
-    return res.status(201).json({ tokens });
+    return res.success({ tokens }, 'User registered', 201);
   },
 );
 
@@ -55,16 +55,16 @@ router.post(
     const { email, password } = req.body;
     const user = await userRepository.findByEmail(email);
     if (!user) {
-      return res.status(401).json({ message: 'Invalid credentials' });
+      return res.error('Invalid credentials', 401);
     }
 
     const valid = await PasswordService.comparePassword(password, user.password_hash);
     if (!valid) {
-      return res.status(401).json({ message: 'Invalid credentials' });
+      return res.error('Invalid credentials', 401);
     }
 
     const tokens = authService.generateTokens(user.id);
-    return res.json({ tokens });
+    return res.success({ tokens }, 'Login successful');
   },
 );
 
@@ -77,14 +77,14 @@ router.post(
   async (req: Request<{}, {}, RefreshBody>, res: Response) => {
     const { refreshToken } = req.body;
     if (!refreshToken) {
-      return res.status(400).json({ message: 'Refresh token required' });
+      return res.error('Refresh token required', 400);
     }
 
     try {
       const tokens = authService.refreshTokens(refreshToken);
-      return res.json({ tokens });
+      return res.success({ tokens }, 'Token refreshed');
     } catch {
-      return res.status(401).json({ message: 'Invalid token' });
+      return res.error('Invalid token', 401);
     }
   },
 );
@@ -104,7 +104,7 @@ router.post(
     if (refreshToken) {
       authService.blacklistToken(refreshToken);
     }
-    return res.status(204).send();
+    return res.success(null, 'Logged out');
   },
 );
 

--- a/backend/src/routes/user.routes.ts
+++ b/backend/src/routes/user.routes.ts
@@ -6,15 +6,15 @@ const router = Router();
 
 router.get('/profile', authenticateToken, (req: Request, res: Response) => {
   if (!req.user) {
-    return res.status(401).json({ message: 'Unauthorized' });
+    return res.error('Unauthorized', 401);
   }
   const { password_hash, ...user } = req.user;
-  return res.json({ user });
+  return res.success({ user });
 });
 
 router.put('/profile', authenticateToken, async (req: Request, res: Response) => {
   if (!req.user) {
-    return res.status(401).json({ message: 'Unauthorized' });
+    return res.error('Unauthorized', 401);
   }
   const { first_name, last_name } = req.body as {
     first_name?: string;
@@ -25,15 +25,15 @@ router.put('/profile', authenticateToken, async (req: Request, res: Response) =>
     last_name: last_name ?? req.user.last_name,
   });
   const { password_hash, ...user } = updated;
-  return res.json({ user });
+  return res.success({ user }, 'Profile updated');
 });
 
 router.delete('/account', authenticateToken, async (req: Request, res: Response) => {
   if (!req.user) {
-    return res.status(401).json({ message: 'Unauthorized' });
+    return res.error('Unauthorized', 401);
   }
   await userRepository.delete(req.user.id);
-  return res.status(204).send();
+  return res.success(null, 'Account deleted');
 });
 
 export default router;

--- a/backend/src/utils/response.util.ts
+++ b/backend/src/utils/response.util.ts
@@ -1,0 +1,50 @@
+// Utility functions for standardized API responses
+export interface ApiResponse<T = unknown> {
+  success: boolean;
+  data?: T;
+  error?: unknown;
+  message: string;
+  timestamp: string;
+  pagination?: unknown;
+}
+
+export const success = <T>(
+  data: T,
+  message = 'OK',
+  _statusCode = 200,
+): ApiResponse<T> => ({
+  success: true,
+  data,
+  message,
+  timestamp: new Date().toISOString(),
+});
+
+export const error = (
+  message: string,
+  _statusCode = 500,
+  details?: unknown,
+): ApiResponse => {
+  const response: ApiResponse = {
+    success: false,
+    message,
+    timestamp: new Date().toISOString(),
+  };
+  if (details !== undefined) {
+    response.error = details;
+  }
+  return response;
+};
+
+export const paginated = <T>(
+  data: T,
+  pagination: unknown,
+  message = 'OK',
+  _statusCode = 200,
+): ApiResponse<T> => ({
+  success: true,
+  data,
+  pagination,
+  message,
+  timestamp: new Date().toISOString(),
+});
+

--- a/codex/daten/changelog.md
+++ b/codex/daten/changelog.md
@@ -125,3 +125,8 @@
 - Globale Fehlerbehandlungs-Middleware `error.middleware.ts` erstellt
 - Einheitliches Fehlerformat `{ error: { message, code, details } }` implementiert
 - Middleware in `src/index.ts` registriert und Roadmap aktualisiert
+
+### Phase 1: API Response Standardization - 2025-08-08
+- Einheitliche Response-Helfer in `response.util.ts` implementiert
+- Response-Wrapper-Middleware registriert und bestehende Routen angepasst
+- Roadmap aktualisiert

--- a/codex/daten/prompt.md
+++ b/codex/daten/prompt.md
@@ -1,4 +1,4 @@
-# Nächster Schritt: Phase 1 – `API Response Standardization`
+# Nächster Schritt: Phase 1 – `Login Screen UI Layout`
 
 ## Status
 - Phase 0 abgeschlossen ✓
@@ -27,6 +27,7 @@
 - Authentication Middleware implementiert ✓
 - Basic API Routes Setup implementiert ✓
 - Error Handling Middleware implementiert ✓
+- API Response Standardization implementiert ✓
 
 ## Referenzen
 - `/README.md`
@@ -34,20 +35,21 @@
 - `/codex/daten/roadmap.md`
 - `/codex/daten/changelog.md`
 
-## Nächste Aufgabe: `API Response Standardization`
+## Nächste Aufgabe: `Login Screen UI Layout`
 
 ### Vorbereitungen
-- Navigiere zum Projekt-Root `backend/`.
+- Navigiere zum Projekt-Root `flutter_app/`.
 
 ### Implementierungsschritte
-- `src/utils/response.util.ts` erstellen.
-- Helper-Funktionen `success(data, message, statusCode)`, `error(message, statusCode, details)` und `paginated(data, pagination)` implementieren.
-- Einheitliches API-Response-Format `{ success: boolean, data?: object, error?: object, message: string, timestamp: string }` sicherstellen.
-- Response-Wrapper-Middleware implementieren und in `src/index.ts` registrieren.
+- `lib/features/auth/presentation/pages/login_page.dart` erstellen.
+- `LoginPage` als `StatefulWidget` mit `Scaffold` und `AppBar(title: 'Login')` implementieren.
+- Body als `SingleChildScrollView` mit Logo-Container (150x150), Titel "Willkommen bei Mrs-Unkwn".
+- Zwei `TextFormField` für Email und Password mit `InputDecoration`.
+- `ElevatedButton` zum Login und `TextButton` für "Registrieren".
 
 ### Validierung
-- `npx tsc --noEmit`.
-- `npm test` (falls Tests vorhanden).
+- `flutter format lib/features/auth/presentation/pages/login_page.dart`.
+- `flutter analyze`.
 
 ### Selbstgenerierung
 - Nach Abschluss dieses Schrittes automatisch den nächsten Prompt in `/codex/daten/prompt.md` schreiben.

--- a/codex/daten/roadmap.md
+++ b/codex/daten/roadmap.md
@@ -96,7 +96,7 @@ Details: Erstelle `src/routes/` Ordner. Implementiere `auth.routes.ts` mit Expre
 [x] Error Handling Middleware:
 Details: Erstelle `src/middleware/error.middleware.ts`. Implementiere global Error-Handler-Middleware die alle unhandled Errors abfängt. Unterscheide zwischen verschiedenen Error-Types: ValidationError, DatabaseError, AuthenticationError, etc. Erstelle standardisierte Error-Response-Format: `{error: {message, code, details}}`. Implementiere different Error-Handling für Development vs Production (Stack-Traces nur in Dev).
 
-[ ] API Response Standardization:
+[x] API Response Standardization:
 Details: Erstelle `src/utils/response.util.ts`. Implementiere Helper-Functions: `success(data, message, statusCode)`, `error(message, statusCode, details)`, `paginated(data, pagination)`. Alle API-Responses sollen einheitliches Format haben: `{success: boolean, data/error: object, message: string, timestamp: string}`. Implementiere Response-Wrapper-Middleware die automatisch alle Responses formatiert.
 
 ### Milestone 3: Flutter Authentication UI


### PR DESCRIPTION
## Summary
- add reusable API response utilities and middleware
- update backend routes and middleware to use standardized success/error responses
- document API response standardization and advance roadmap

## Testing
- `npx tsc --noEmit`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68955c99269c832eafcb40d3a3ca05cf