### PR TITLE
feat: add login form validation

### DIFF
--- a/codex/daten/changelog.md
+++ b/codex/daten/changelog.md
@@ -134,3 +134,9 @@
 ### Phase 1: Login Screen UI Layout - 2025-08-08
 - Login-Layout in `lib/features/auth/presentation/pages/login_page.dart` erstellt
 - Roadmap aktualisiert
+
+### Phase 1: Login Form Validation implementieren - 2025-08-08
+- Formularvalidierung mit `GlobalKey<FormState>` und RegExp für Email umgesetzt
+- Passwortfeld mit Mindestlänge und Toggle für Sichtbarkeit ergänzt
+- `_validateAndSubmit()` Methode hinzugefügt
+- `dart format` und `flutter analyze` (Dependencies fehlen) ausgeführt

--- a/codex/daten/prompt.md
+++ b/codex/daten/prompt.md
@@ -1,4 +1,4 @@
-# Nächster Schritt: Phase 1 – `Login Form Validation`
+# Nächster Schritt: Phase 1 – `Login BLoC State Management`
 
 ## Status
 - Phase 0 abgeschlossen ✓
@@ -29,6 +29,7 @@
 - Error Handling Middleware implementiert ✓
 - API Response Standardization implementiert ✓
 - Login Screen UI Layout erstellt ✓
+- Login Form Validation implementiert ✓
 
 ## Referenzen
 - `/README.md`
@@ -36,23 +37,23 @@
 - `/codex/daten/roadmap.md`
 - `/codex/daten/changelog.md`
 
-## Nächste Aufgabe: `Login Form Validation`
+## Nächste Aufgabe: `Login BLoC State Management`
 
 ### Vorbereitungen
 - Navigiere zum Projekt-Root `flutter_app/`.
 
 ### Implementierungsschritte
-- In `lib/features/auth/presentation/pages/login_page.dart` `GlobalKey<FormState> _formKey` definieren.
-- `TextFormField`s in ein `Form` Widget mit `key: _formKey` einbetten.
-- Email-Feld: Validierungsfunktion für korrektes Email-Format.
-- Passwort-Feld: Validierung für mindestens 6 Zeichen, `obscureText` mit Toggle-Icon.
-- Methode `_validateAndSubmit()` erstellen, die `_formKey.currentState?.validate()` aufruft.
+- Datei `lib/features/auth/presentation/bloc/auth_bloc.dart` erstellen.
+- `AuthEvent` mit `LoginRequested(email, password)`, `LogoutRequested`, `AuthStatusChanged` definieren.
+- `AuthState` mit `AuthInitial`, `AuthLoading`, `AuthSuccess(User)`, `AuthFailure(String message)` implementieren.
+- `AuthBloc` mit Event-Handling und Repository-Aufrufen implementieren.
 
 ### Validierung
-- `flutter format lib/features/auth/presentation/pages/login_page.dart`.
+- `dart format lib/features/auth/presentation/bloc/auth_bloc.dart`.
 - `flutter analyze`.
 
 ### Selbstgenerierung
 - Nach Abschluss dieses Schrittes automatisch den nächsten Prompt in `/codex/daten/prompt.md` schreiben.
 
 *Hinweis: Codex kann keine Binärdateien mergen. Benötigte Dateien müssen durch Skripte generiert werden. Halte den Codeumfang dieses Sprints unter 500 Zeilen.*
+

--- a/codex/daten/roadmap.md
+++ b/codex/daten/roadmap.md
@@ -104,7 +104,7 @@ Details: Erstelle `src/utils/response.util.ts`. Implementiere Helper-Functions: 
  [x] Login Screen UI Layout erstellen:
 Details: Erstelle `lib/features/auth/presentation/pages/login_page.dart`. Implementiere `LoginPage` als `StatefulWidget`. Erstelle UI-Layout mit `Scaffold`, `AppBar(title: 'Login')`, `SingleChildScrollView` Body. Füge Logo-Container hinzu (150x150), Titel-Text "Willkommen bei Mrs-Unkwn". Implementiere zwei `TextFormField` für Email und Password mit entsprechenden `InputDecoration`. Füge `ElevatedButton` für Login und `TextButton` für "Registrieren" Link hinzu.
 
-[ ] Login Form Validation implementieren:
+[x] Login Form Validation implementieren:
 Details: In `LoginPage`, erstelle `GlobalKey<FormState> _formKey`. Wrappen Sie Form-Fields in `Form` Widget mit `key: _formKey`. Für Email-Field: Validation-Function die Email-Format prüft mit RegExp. Für Password-Field: Validation für minimum 6 Zeichen, required Field. Implementiere `obscureText: true` für Password-Field mit Toggle-Icon. Erstelle `_validateAndSubmit()` Methode die `_formKey.currentState?.validate()` aufruft.
 
 [ ] Login BLoC State Management:

--- a/flutter_app/mrs_unkwn_app/lib/features/auth/presentation/pages/login_page.dart
+++ b/flutter_app/mrs_unkwn_app/lib/features/auth/presentation/pages/login_page.dart
@@ -8,43 +8,82 @@ class LoginPage extends StatefulWidget {
 }
 
 class _LoginPageState extends State<LoginPage> {
+  final GlobalKey<FormState> _formKey = GlobalKey<FormState>();
+  bool _obscurePassword = true;
+
+  void _validateAndSubmit() {
+    if (_formKey.currentState?.validate() ?? false) {
+      // Submit logic will be implemented in future steps
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(title: const Text('Login')),
       body: SingleChildScrollView(
         padding: const EdgeInsets.all(16),
-        child: Column(
-          children: [
-            Container(
-              height: 150,
-              width: 150,
-              color: Colors.grey[300],
-            ),
-            const SizedBox(height: 16),
-            const Text('Willkommen bei Mrs-Unkwn'),
-            const SizedBox(height: 24),
-            TextFormField(
-              decoration: const InputDecoration(labelText: 'Email'),
-            ),
-            const SizedBox(height: 16),
-            TextFormField(
-              decoration: const InputDecoration(labelText: 'Password'),
-              obscureText: true,
-            ),
-            const SizedBox(height: 24),
-            ElevatedButton(
-              onPressed: () {},
-              child: const Text('Login'),
-            ),
-            TextButton(
-              onPressed: () {},
-              child: const Text('Registrieren'),
-            ),
-          ],
+        child: Form(
+          key: _formKey,
+          child: Column(
+            children: [
+              Container(height: 150, width: 150, color: Colors.grey[300]),
+              const SizedBox(height: 16),
+              const Text('Willkommen bei Mrs-Unkwn'),
+              const SizedBox(height: 24),
+              TextFormField(
+                decoration: const InputDecoration(labelText: 'Email'),
+                validator: (value) {
+                  if (value == null || value.isEmpty) {
+                    return 'Bitte Email eingeben';
+                  }
+                  final emailRegex = RegExp(
+                    r'^[\w\.-]+@[\w\.-]+\.[a-zA-Z]{2,4}$',
+                  );
+                  if (!emailRegex.hasMatch(value)) {
+                    return 'Ungültiges Email-Format';
+                  }
+                  return null;
+                },
+              ),
+              const SizedBox(height: 16),
+              TextFormField(
+                decoration: InputDecoration(
+                  labelText: 'Password',
+                  suffixIcon: IconButton(
+                    icon: Icon(
+                      _obscurePassword
+                          ? Icons.visibility_off
+                          : Icons.visibility,
+                    ),
+                    onPressed: () {
+                      setState(() {
+                        _obscurePassword = !_obscurePassword;
+                      });
+                    },
+                  ),
+                ),
+                obscureText: _obscurePassword,
+                validator: (value) {
+                  if (value == null || value.isEmpty) {
+                    return 'Bitte Passwort eingeben';
+                  }
+                  if (value.length < 6) {
+                    return 'Mindestens 6 Zeichen';
+                  }
+                  return null;
+                },
+              ),
+              const SizedBox(height: 24),
+              ElevatedButton(
+                onPressed: _validateAndSubmit,
+                child: const Text('Login'),
+              ),
+              TextButton(onPressed: () {}, child: const Text('Registrieren')),
+            ],
+          ),
         ),
       ),
     );
   }
 }
-


### PR DESCRIPTION
## Summary
- implement login form validation with email and password checks
- document progress in roadmap, changelog and next sprint prompt

## Testing
- `dart format lib/features/auth/presentation/pages/login_page.dart`
- `flutter analyze` *(fails: Target of URI doesn't exist: 'package:flutter/material.dart')*


------
https://chatgpt.com/codex/tasks/task_e_689564905470832eb0cb59ed2efaffeb