### PR TITLE
feat(auth): add login bloc state management

### DIFF
--- a/codex/daten/changelog.md
+++ b/codex/daten/changelog.md
@@ -140,3 +140,7 @@
 - Passwortfeld mit Mindestlänge und Toggle für Sichtbarkeit ergänzt
 - `_validateAndSubmit()` Methode hinzugefügt
 - `dart format` und `flutter analyze` (Dependencies fehlen) ausgeführt
+
+### Phase 1: Login BLoC State Management - 2025-08-08
+- `auth_bloc.dart` mit Events, States und AuthBloc implementiert
+- Roadmap aktualisiert

--- a/codex/daten/prompt.md
+++ b/codex/daten/prompt.md
@@ -1,4 +1,4 @@
-# Nächster Schritt: Phase 1 – `Login BLoC State Management`
+# Nächster Schritt: Phase 1 – `Login API Integration`
 
 ## Status
 - Phase 0 abgeschlossen ✓
@@ -30,6 +30,7 @@
 - API Response Standardization implementiert ✓
 - Login Screen UI Layout erstellt ✓
 - Login Form Validation implementiert ✓
+- Login BLoC State Management implementiert ✓
 
 ## Referenzen
 - `/README.md`
@@ -37,19 +38,20 @@
 - `/codex/daten/roadmap.md`
 - `/codex/daten/changelog.md`
 
-## Nächste Aufgabe: `Login BLoC State Management`
+## Nächste Aufgabe: `Login API Integration`
 
 ### Vorbereitungen
 - Navigiere zum Projekt-Root `flutter_app/`.
 
 ### Implementierungsschritte
-- Datei `lib/features/auth/presentation/bloc/auth_bloc.dart` erstellen.
-- `AuthEvent` mit `LoginRequested(email, password)`, `LogoutRequested`, `AuthStatusChanged` definieren.
-- `AuthState` mit `AuthInitial`, `AuthLoading`, `AuthSuccess(User)`, `AuthFailure(String message)` implementieren.
-- `AuthBloc` mit Event-Handling und Repository-Aufrufen implementieren.
+- Datei `lib/features/auth/data/repositories/auth_repository_impl.dart` erstellen.
+- `login(String email, String password)` Methode implementieren.
+- POST-Request zu `/api/auth/login` mit Email/Password im Body senden.
+- Erfolgsantwort parsen, Tokens in `SecureStorageService` speichern.
+- Fehlerantworten abfangen und passende Exception mit Fehlermeldung werfen.
 
 ### Validierung
-- `dart format lib/features/auth/presentation/bloc/auth_bloc.dart`.
+- `dart format lib/features/auth/data/repositories/auth_repository_impl.dart`.
 - `flutter analyze`.
 
 ### Selbstgenerierung

--- a/codex/daten/roadmap.md
+++ b/codex/daten/roadmap.md
@@ -107,7 +107,7 @@ Details: Erstelle `lib/features/auth/presentation/pages/login_page.dart`. Implem
 [x] Login Form Validation implementieren:
 Details: In `LoginPage`, erstelle `GlobalKey<FormState> _formKey`. Wrappen Sie Form-Fields in `Form` Widget mit `key: _formKey`. Für Email-Field: Validation-Function die Email-Format prüft mit RegExp. Für Password-Field: Validation für minimum 6 Zeichen, required Field. Implementiere `obscureText: true` für Password-Field mit Toggle-Icon. Erstelle `_validateAndSubmit()` Methode die `_formKey.currentState?.validate()` aufruft.
 
-[ ] Login BLoC State Management:
+[x] Login BLoC State Management:
 Details: Erstelle `lib/features/auth/presentation/bloc/auth_bloc.dart`. Definiere `AuthEvent` Klasse mit `LoginRequested(email, password)`, `LogoutRequested`, `AuthStatusChanged` Events. Definiere `AuthState` mit `AuthInitial`, `AuthLoading`, `AuthSuccess(User)`, `AuthFailure(String message)` States. Implementiere `AuthBloc` die Events handled und entsprechende States emittiert. Verwende Repository-Pattern für API-Calls.
 
 [ ] Login API Integration:

--- a/flutter_app/mrs_unkwn_app/lib/features/auth/presentation/bloc/auth_bloc.dart
+++ b/flutter_app/mrs_unkwn_app/lib/features/auth/presentation/bloc/auth_bloc.dart
@@ -1,0 +1,95 @@
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+/// Simple user placeholder. Replace with actual user model when available.
+class User {
+  const User({required this.id});
+  final String id;
+}
+
+// Events
+abstract class AuthEvent {}
+
+class LoginRequested extends AuthEvent {
+  LoginRequested(this.email, this.password);
+  final String email;
+  final String password;
+}
+
+class LogoutRequested extends AuthEvent {}
+
+class AuthStatusChanged extends AuthEvent {
+  AuthStatusChanged(this.user);
+  final User? user;
+}
+
+// States
+abstract class AuthState {}
+
+class AuthInitial extends AuthState {}
+
+class AuthLoading extends AuthState {}
+
+class AuthSuccess extends AuthState {
+  AuthSuccess(this.user);
+  final User user;
+}
+
+class AuthFailure extends AuthState {
+  AuthFailure(this.message);
+  final String message;
+}
+
+// Repository interface
+abstract class AuthRepository {
+  Future<User> login(String email, String password);
+  Future<void> logout();
+}
+
+// Bloc
+class AuthBloc extends Bloc<AuthEvent, AuthState> {
+  AuthBloc(this._repository) : super(AuthInitial()) {
+    on<LoginRequested>(_onLoginRequested);
+    on<LogoutRequested>(_onLogoutRequested);
+    on<AuthStatusChanged>(_onAuthStatusChanged);
+  }
+
+  final AuthRepository _repository;
+
+  Future<void> _onLoginRequested(
+    LoginRequested event,
+    Emitter<AuthState> emit,
+  ) async {
+    emit(AuthLoading());
+    try {
+      final user = await _repository.login(event.email, event.password);
+      emit(AuthSuccess(user));
+    } catch (e) {
+      emit(AuthFailure(e.toString()));
+    }
+  }
+
+  Future<void> _onLogoutRequested(
+    LogoutRequested event,
+    Emitter<AuthState> emit,
+  ) async {
+    emit(AuthLoading());
+    try {
+      await _repository.logout();
+      emit(AuthInitial());
+    } catch (e) {
+      emit(AuthFailure(e.toString()));
+    }
+  }
+
+  void _onAuthStatusChanged(
+    AuthStatusChanged event,
+    Emitter<AuthState> emit,
+  ) {
+    final user = event.user;
+    if (user != null) {
+      emit(AuthSuccess(user));
+    } else {
+      emit(AuthInitial());
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- implement AuthBloc with login, logout, and status events
- document completion in roadmap and changelog
- advance prompt to Login API Integration

## Testing
- `dart format lib/features/auth/presentation/bloc/auth_bloc.dart` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6895688ba3ac832e8d05742b20f399c8