### PR TITLE
feat: implement login API repository

### DIFF
--- a/codex/daten/changelog.md
+++ b/codex/daten/changelog.md
@@ -144,3 +144,8 @@
 ### Phase 1: Login BLoC State Management - 2025-08-08
 - `auth_bloc.dart` mit Events, States und AuthBloc implementiert
 - Roadmap aktualisiert
+
+### Phase 1: Login API Integration - 2025-08-08
+- `auth_repository_impl.dart` mit Login- und Logout-Logik erstellt
+- Tokens werden nach erfolgreichem Login sicher gespeichert
+- `dart format` und `flutter analyze` (Werkzeuge nicht verfügbar) ausgeführt

--- a/codex/daten/prompt.md
+++ b/codex/daten/prompt.md
@@ -1,4 +1,4 @@
-# Nächster Schritt: Phase 1 – `Login API Integration`
+# Nächster Schritt: Phase 1 – `Login Loading States UI`
 
 ## Status
 - Phase 0 abgeschlossen ✓
@@ -31,6 +31,7 @@
 - Login Screen UI Layout erstellt ✓
 - Login Form Validation implementiert ✓
 - Login BLoC State Management implementiert ✓
+- Login API Integration implementiert ✓
 
 ## Referenzen
 - `/README.md`
@@ -38,20 +39,21 @@
 - `/codex/daten/roadmap.md`
 - `/codex/daten/changelog.md`
 
-## Nächste Aufgabe: `Login API Integration`
+## Nächste Aufgabe: `Login Loading States UI`
 
 ### Vorbereitungen
 - Navigiere zum Projekt-Root `flutter_app/`.
 
 ### Implementierungsschritte
-- Datei `lib/features/auth/data/repositories/auth_repository_impl.dart` erstellen.
-- `login(String email, String password)` Methode implementieren.
-- POST-Request zu `/api/auth/login` mit Email/Password im Body senden.
-- Erfolgsantwort parsen, Tokens in `SecureStorageService` speichern.
-- Fehlerantworten abfangen und passende Exception mit Fehlermeldung werfen.
+- Datei `lib/features/auth/presentation/pages/login_page.dart` anpassen.
+- Gesamte UI in `BlocConsumer<AuthBloc, AuthState>` wrappen.
+- Im `listener` `AuthSuccess` (Navigation zu Home) und `AuthFailure` (SnackBar) behandeln.
+- Im `builder` bei `AuthLoading` Ladeanzeige anzeigen.
+- Login-Button während Loading deaktivieren.
+- Im Loading-State `ElevatedButton`-Child durch `CircularProgressIndicator()` ersetzen.
 
 ### Validierung
-- `dart format lib/features/auth/data/repositories/auth_repository_impl.dart`.
+- `dart format lib/features/auth/presentation/pages/login_page.dart`.
 - `flutter analyze`.
 
 ### Selbstgenerierung

--- a/codex/daten/roadmap.md
+++ b/codex/daten/roadmap.md
@@ -110,7 +110,7 @@ Details: In `LoginPage`, erstelle `GlobalKey<FormState> _formKey`. Wrappen Sie F
 [x] Login BLoC State Management:
 Details: Erstelle `lib/features/auth/presentation/bloc/auth_bloc.dart`. Definiere `AuthEvent` Klasse mit `LoginRequested(email, password)`, `LogoutRequested`, `AuthStatusChanged` Events. Definiere `AuthState` mit `AuthInitial`, `AuthLoading`, `AuthSuccess(User)`, `AuthFailure(String message)` States. Implementiere `AuthBloc` die Events handled und entsprechende States emittiert. Verwende Repository-Pattern für API-Calls.
 
-[ ] Login API Integration:
+[x] Login API Integration:
 Details: Erstelle `lib/features/auth/data/repositories/auth_repository_impl.dart`. Implementiere `login(String email, String password)` Methode. Erstelle POST-Request zu `/api/auth/login` mit Email/Password im Body. Handle HTTP-Response: Bei 200 Status, parse JSON und extrahiere Token. Speichere Access-Token und Refresh-Token in Secure-Storage. Bei Error-Response, werfe entsprechende Exception mit Error-Message.
 
 [ ] Login Loading States UI:


### PR DESCRIPTION
## Summary
- implement AuthRepositoryImpl for login API calls and token storage
- log the login integration in changelog and update roadmap
- prepare next prompt for Login Loading States UI

## Testing
- `dart format lib/features/auth/data/repositories/auth_repository_impl.dart` *(command not found)*
- `apt-get install -y dart` *(unable to locate package)*
- `flutter analyze` *(command not found)*
- `apt-get install -y flutter` *(unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68956c877170832ea9316e430743dce1