### PR TITLE
feat: add login loading states

### DIFF
--- a/codex/daten/changelog.md
+++ b/codex/daten/changelog.md
@@ -149,3 +149,8 @@
 - `auth_repository_impl.dart` mit Login- und Logout-Logik erstellt
 - Tokens werden nach erfolgreichem Login sicher gespeichert
 - `dart format` und `flutter analyze` (Werkzeuge nicht verfügbar) ausgeführt
+
+### Phase 1: Login Loading States UI - 2025-08-08
+- UI in `login_page.dart` mit `BlocConsumer` um BLoC-Stati erweitert
+- Navigation bei Erfolg und SnackBar bei Fehler implementiert
+- Login-Button zeigt Ladeindikator und ist während Loading deaktiviert

--- a/codex/daten/prompt.md
+++ b/codex/daten/prompt.md
@@ -1,4 +1,4 @@
-# Nächster Schritt: Phase 1 – `Login Loading States UI`
+# Nächster Schritt: Phase 1 – `Register Screen UI Layout`
 
 ## Status
 - Phase 0 abgeschlossen ✓
@@ -32,6 +32,7 @@
 - Login Form Validation implementiert ✓
 - Login BLoC State Management implementiert ✓
 - Login API Integration implementiert ✓
+- Login Loading States UI implementiert ✓
 
 ## Referenzen
 - `/README.md`
@@ -39,21 +40,20 @@
 - `/codex/daten/roadmap.md`
 - `/codex/daten/changelog.md`
 
-## Nächste Aufgabe: `Login Loading States UI`
+## Nächste Aufgabe: `Register Screen UI Layout`
 
 ### Vorbereitungen
 - Navigiere zum Projekt-Root `flutter_app/`.
 
 ### Implementierungsschritte
-- Datei `lib/features/auth/presentation/pages/login_page.dart` anpassen.
-- Gesamte UI in `BlocConsumer<AuthBloc, AuthState>` wrappen.
-- Im `listener` `AuthSuccess` (Navigation zu Home) und `AuthFailure` (SnackBar) behandeln.
-- Im `builder` bei `AuthLoading` Ladeanzeige anzeigen.
-- Login-Button während Loading deaktivieren.
-- Im Loading-State `ElevatedButton`-Child durch `CircularProgressIndicator()` ersetzen.
+- Neue Datei `lib/features/auth/presentation/pages/register_page.dart` erstellen.
+- Layout analog zur `LoginPage` mit zusätzlichen Feldern `firstName`, `lastName`, `confirmPassword`.
+- `DropdownButtonFormField` für User-Role (Parent/Child) einfügen.
+- Checkbox für Terms-Acceptance mit Link zur Terms-Page hinzufügen.
+- Validierung: Password-Bestätigung und Terms-Akzeptanz müssen erfüllt sein.
 
 ### Validierung
-- `dart format lib/features/auth/presentation/pages/login_page.dart`.
+- `dart format lib/features/auth/presentation/pages/register_page.dart`.
 - `flutter analyze`.
 
 ### Selbstgenerierung

--- a/codex/daten/roadmap.md
+++ b/codex/daten/roadmap.md
@@ -113,7 +113,7 @@ Details: Erstelle `lib/features/auth/presentation/bloc/auth_bloc.dart`. Definier
 [x] Login API Integration:
 Details: Erstelle `lib/features/auth/data/repositories/auth_repository_impl.dart`. Implementiere `login(String email, String password)` Methode. Erstelle POST-Request zu `/api/auth/login` mit Email/Password im Body. Handle HTTP-Response: Bei 200 Status, parse JSON und extrahiere Token. Speichere Access-Token und Refresh-Token in Secure-Storage. Bei Error-Response, werfe entsprechende Exception mit Error-Message.
 
-[ ] Login Loading States UI:
+[x] Login Loading States UI:
 Details: In `LoginPage`, wrappen Sie gesamte UI in `BlocConsumer<AuthBloc, AuthState>`. Im `listener`, handle `AuthSuccess` State (Navigate zu Home), `AuthFailure` State (Show-SnackBar mit Error). Im `builder`, zeige Loading-Indicator wenn State `AuthLoading` ist. Disable Login-Button während Loading. Replace ElevatedButton-Child mit `CircularProgressIndicator()` bei Loading-State.
 
 [ ] Register Screen UI erstellen:

--- a/flutter_app/mrs_unkwn_app/lib/features/auth/presentation/pages/login_page.dart
+++ b/flutter_app/mrs_unkwn_app/lib/features/auth/presentation/pages/login_page.dart
@@ -1,4 +1,9 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:go_router/go_router.dart';
+
+import '../bloc/auth_bloc.dart';
+import '../../../../core/routing/route_constants.dart';
 
 class LoginPage extends StatefulWidget {
   const LoginPage({super.key});
@@ -19,71 +24,94 @@ class _LoginPageState extends State<LoginPage> {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(title: const Text('Login')),
-      body: SingleChildScrollView(
-        padding: const EdgeInsets.all(16),
-        child: Form(
-          key: _formKey,
-          child: Column(
-            children: [
-              Container(height: 150, width: 150, color: Colors.grey[300]),
-              const SizedBox(height: 16),
-              const Text('Willkommen bei Mrs-Unkwn'),
-              const SizedBox(height: 24),
-              TextFormField(
-                decoration: const InputDecoration(labelText: 'Email'),
-                validator: (value) {
-                  if (value == null || value.isEmpty) {
-                    return 'Bitte Email eingeben';
-                  }
-                  final emailRegex = RegExp(
-                    r'^[\w\.-]+@[\w\.-]+\.[a-zA-Z]{2,4}$',
-                  );
-                  if (!emailRegex.hasMatch(value)) {
-                    return 'Ungültiges Email-Format';
-                  }
-                  return null;
-                },
-              ),
-              const SizedBox(height: 16),
-              TextFormField(
-                decoration: InputDecoration(
-                  labelText: 'Password',
-                  suffixIcon: IconButton(
-                    icon: Icon(
-                      _obscurePassword
-                          ? Icons.visibility_off
-                          : Icons.visibility,
-                    ),
-                    onPressed: () {
-                      setState(() {
-                        _obscurePassword = !_obscurePassword;
-                      });
+    return BlocConsumer<AuthBloc, AuthState>(
+      listener: (context, state) {
+        if (state is AuthSuccess) {
+          context.go(RouteConstants.home);
+        } else if (state is AuthFailure) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(content: Text(state.message)),
+          );
+        }
+      },
+      builder: (context, state) {
+        final isLoading = state is AuthLoading;
+        return Scaffold(
+          appBar: AppBar(title: const Text('Login')),
+          body: SingleChildScrollView(
+            padding: const EdgeInsets.all(16),
+            child: Form(
+              key: _formKey,
+              child: Column(
+                children: [
+                  Container(height: 150, width: 150, color: Colors.grey[300]),
+                  const SizedBox(height: 16),
+                  const Text('Willkommen bei Mrs-Unkwn'),
+                  const SizedBox(height: 24),
+                  TextFormField(
+                    decoration: const InputDecoration(labelText: 'Email'),
+                    validator: (value) {
+                      if (value == null || value.isEmpty) {
+                        return 'Bitte Email eingeben';
+                      }
+                      final emailRegex = RegExp(
+                        r'^[\w\.-]+@[\w\.-]+\.[a-zA-Z]{2,4}$',
+                      );
+                      if (!emailRegex.hasMatch(value)) {
+                        return 'Ungültiges Email-Format';
+                      }
+                      return null;
                     },
                   ),
-                ),
-                obscureText: _obscurePassword,
-                validator: (value) {
-                  if (value == null || value.isEmpty) {
-                    return 'Bitte Passwort eingeben';
-                  }
-                  if (value.length < 6) {
-                    return 'Mindestens 6 Zeichen';
-                  }
-                  return null;
-                },
+                  const SizedBox(height: 16),
+                  TextFormField(
+                    decoration: InputDecoration(
+                      labelText: 'Password',
+                      suffixIcon: IconButton(
+                        icon: Icon(
+                          _obscurePassword
+                              ? Icons.visibility_off
+                              : Icons.visibility,
+                        ),
+                        onPressed: () {
+                          setState(() {
+                            _obscurePassword = !_obscurePassword;
+                          });
+                        },
+                      ),
+                    ),
+                    obscureText: _obscurePassword,
+                    validator: (value) {
+                      if (value == null || value.isEmpty) {
+                        return 'Bitte Passwort eingeben';
+                      }
+                      if (value.length < 6) {
+                        return 'Mindestens 6 Zeichen';
+                      }
+                      return null;
+                    },
+                  ),
+                  const SizedBox(height: 24),
+                  ElevatedButton(
+                    onPressed: isLoading ? null : _validateAndSubmit,
+                    child: isLoading
+                        ? const SizedBox(
+                            width: 24,
+                            height: 24,
+                            child: CircularProgressIndicator(strokeWidth: 2),
+                          )
+                        : const Text('Login'),
+                  ),
+                  TextButton(
+                    onPressed: () {},
+                    child: const Text('Registrieren'),
+                  ),
+                ],
               ),
-              const SizedBox(height: 24),
-              ElevatedButton(
-                onPressed: _validateAndSubmit,
-                child: const Text('Login'),
-              ),
-              TextButton(onPressed: () {}, child: const Text('Registrieren')),
-            ],
+            ),
           ),
-        ),
-      ),
+        );
+      },
     );
   }
 }


### PR DESCRIPTION
## Summary
- show login progress via `BlocConsumer` and disable button while loading
- record login loading UI completion in roadmap, changelog and next prompt

## Testing
- `dart format lib/features/auth/presentation/pages/login_page.dart` *(failed: command not found)*
- `flutter analyze` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689570830390832e828096196950b6f1