### PR TITLE
feat: add register screen UI layout

### DIFF
--- a/codex/daten/changelog.md
+++ b/codex/daten/changelog.md
@@ -154,3 +154,8 @@
 - UI in `login_page.dart` mit `BlocConsumer` um BLoC-Stati erweitert
 - Navigation bei Erfolg und SnackBar bei Fehler implementiert
 - Login-Button zeigt Ladeindikator und ist während Loading deaktiviert
+
+### Phase 1: Register Screen UI Layout - 2025-08-08
+- `register_page.dart` mit Feldern für Vorname, Nachname, Email, Passwortbestätigung und Rollenwahl erstellt
+- Checkbox für Nutzungsbedingungen mit Validierung hinzugefügt
+- Roadmap aktualisiert

--- a/codex/daten/prompt.md
+++ b/codex/daten/prompt.md
@@ -1,4 +1,4 @@
-# Nächster Schritt: Phase 1 – `Register Screen UI Layout`
+# Nächster Schritt: Phase 1 – `Registration BLoC Events/States`
 
 ## Status
 - Phase 0 abgeschlossen ✓
@@ -33,6 +33,7 @@
 - Login BLoC State Management implementiert ✓
 - Login API Integration implementiert ✓
 - Login Loading States UI implementiert ✓
+- Register Screen UI Layout implementiert ✓
 
 ## Referenzen
 - `/README.md`
@@ -40,20 +41,18 @@
 - `/codex/daten/roadmap.md`
 - `/codex/daten/changelog.md`
 
-## Nächste Aufgabe: `Register Screen UI Layout`
+## Nächste Aufgabe: `Registration BLoC Events/States`
 
 ### Vorbereitungen
 - Navigiere zum Projekt-Root `flutter_app/`.
 
 ### Implementierungsschritte
-- Neue Datei `lib/features/auth/presentation/pages/register_page.dart` erstellen.
-- Layout analog zur `LoginPage` mit zusätzlichen Feldern `firstName`, `lastName`, `confirmPassword`.
-- `DropdownButtonFormField` für User-Role (Parent/Child) einfügen.
-- Checkbox für Terms-Acceptance mit Link zur Terms-Page hinzufügen.
-- Validierung: Password-Bestätigung und Terms-Akzeptanz müssen erfüllt sein.
+- `AuthEvent` um `RegisterRequested(firstName, lastName, email, password, role)` erweitern.
+- `AuthState` um `RegisterSuccess` und `RegisterFailure` ergänzen.
+- In `AuthBloc` Handler `_onRegisterRequested` implementieren.
 
 ### Validierung
-- `dart format lib/features/auth/presentation/pages/register_page.dart`.
+- `dart format lib/features/auth/presentation/bloc/auth_bloc.dart`.
 - `flutter analyze`.
 
 ### Selbstgenerierung

--- a/codex/daten/roadmap.md
+++ b/codex/daten/roadmap.md
@@ -116,7 +116,7 @@ Details: Erstelle `lib/features/auth/data/repositories/auth_repository_impl.dart
 [x] Login Loading States UI:
 Details: In `LoginPage`, wrappen Sie gesamte UI in `BlocConsumer<AuthBloc, AuthState>`. Im `listener`, handle `AuthSuccess` State (Navigate zu Home), `AuthFailure` State (Show-SnackBar mit Error). Im `builder`, zeige Loading-Indicator wenn State `AuthLoading` ist. Disable Login-Button während Loading. Replace ElevatedButton-Child mit `CircularProgressIndicator()` bei Loading-State.
 
-[ ] Register Screen UI erstellen:
+[x] Register Screen UI erstellen:
 Details: Erstelle `lib/features/auth/presentation/pages/register_page.dart`. Implementiere ähnliches Layout wie Login mit zusätzlichen Fields: `firstName`, `lastName`, `confirmPassword`. Füge `DropdownButtonFormField` für User-Role (Parent/Child) hinzu. Implementiere Checkbox für Terms-Acceptance mit Link zu Terms-Page. Erstelle komplexere Validation-Logic: Password-Confirmation-Match, Terms-Acceptance-Required.
 
 [ ] Registration BLoC Events/States:

--- a/flutter_app/mrs_unkwn_app/lib/features/auth/presentation/pages/register_page.dart
+++ b/flutter_app/mrs_unkwn_app/lib/features/auth/presentation/pages/register_page.dart
@@ -1,0 +1,238 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:go_router/go_router.dart';
+
+import '../bloc/auth_bloc.dart';
+import '../../../../core/routing/route_constants.dart';
+
+class RegisterPage extends StatefulWidget {
+  const RegisterPage({super.key});
+
+  @override
+  State<RegisterPage> createState() => _RegisterPageState();
+}
+
+class _RegisterPageState extends State<RegisterPage> {
+  final GlobalKey<FormState> _formKey = GlobalKey<FormState>();
+  final TextEditingController _passwordController = TextEditingController();
+  final TextEditingController _confirmPasswordController = TextEditingController();
+  bool _obscurePassword = true;
+  bool _obscureConfirmPassword = true;
+  bool _termsAccepted = false;
+  String _selectedRole = 'Parent';
+
+  @override
+  void dispose() {
+    _passwordController.dispose();
+    _confirmPasswordController.dispose();
+    super.dispose();
+  }
+
+  void _validateAndSubmit() {
+    if (_formKey.currentState?.validate() ?? false) {
+      if (!_termsAccepted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Bitte Nutzungsbedingungen akzeptieren')),
+        );
+        return;
+      }
+      // Submit logic will be implemented in future steps
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocConsumer<AuthBloc, AuthState>(
+      listener: (context, state) {
+        if (state is AuthSuccess) {
+          context.go(RouteConstants.home);
+        } else if (state is AuthFailure) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(content: Text(state.message)),
+          );
+        }
+      },
+      builder: (context, state) {
+        final isLoading = state is AuthLoading;
+        return Scaffold(
+          appBar: AppBar(title: const Text('Registrieren')),
+          body: SingleChildScrollView(
+            padding: const EdgeInsets.all(16),
+            child: Form(
+              key: _formKey,
+              child: Column(
+                children: [
+                  Container(height: 150, width: 150, color: Colors.grey[300]),
+                  const SizedBox(height: 16),
+                  const Text('Account erstellen'),
+                  const SizedBox(height: 24),
+                  Row(
+                    children: [
+                      Expanded(
+                        child: TextFormField(
+                          decoration: const InputDecoration(labelText: 'Vorname'),
+                          validator: (value) {
+                            if (value == null || value.isEmpty) {
+                              return 'Bitte eingeben';
+                            }
+                            return null;
+                          },
+                        ),
+                      ),
+                      const SizedBox(width: 16),
+                      Expanded(
+                        child: TextFormField(
+                          decoration: const InputDecoration(labelText: 'Nachname'),
+                          validator: (value) {
+                            if (value == null || value.isEmpty) {
+                              return 'Bitte eingeben';
+                            }
+                            return null;
+                          },
+                        ),
+                      ),
+                    ],
+                  ),
+                  const SizedBox(height: 16),
+                  TextFormField(
+                    decoration: const InputDecoration(labelText: 'Email'),
+                    validator: (value) {
+                      if (value == null || value.isEmpty) {
+                        return 'Bitte Email eingeben';
+                      }
+                      final emailRegex =
+                          RegExp(r'^[\w\.-]+@[\w\.-]+\.[a-zA-Z]{2,4}\$');
+                      if (!emailRegex.hasMatch(value)) {
+                        return 'Ungültiges Email-Format';
+                      }
+                      return null;
+                    },
+                  ),
+                  const SizedBox(height: 16),
+                  DropdownButtonFormField<String>(
+                    value: _selectedRole,
+                    items: const [
+                      DropdownMenuItem(value: 'Parent', child: Text('Parent')),
+                      DropdownMenuItem(value: 'Child', child: Text('Child')),
+                    ],
+                    onChanged: (value) {
+                      setState(() {
+                        _selectedRole = value ?? 'Parent';
+                      });
+                    },
+                    decoration: const InputDecoration(labelText: 'Rolle'),
+                  ),
+                  const SizedBox(height: 16),
+                  TextFormField(
+                    controller: _passwordController,
+                    decoration: InputDecoration(
+                      labelText: 'Passwort',
+                      suffixIcon: IconButton(
+                        icon: Icon(
+                          _obscurePassword
+                              ? Icons.visibility_off
+                              : Icons.visibility,
+                        ),
+                        onPressed: () {
+                          setState(() {
+                            _obscurePassword = !_obscurePassword;
+                          });
+                        },
+                      ),
+                    ),
+                    obscureText: _obscurePassword,
+                    validator: (value) {
+                      if (value == null || value.isEmpty) {
+                        return 'Bitte Passwort eingeben';
+                      }
+                      if (value.length < 6) {
+                        return 'Mindestens 6 Zeichen';
+                      }
+                      return null;
+                    },
+                  ),
+                  const SizedBox(height: 16),
+                  TextFormField(
+                    controller: _confirmPasswordController,
+                    decoration: InputDecoration(
+                      labelText: 'Passwort bestätigen',
+                      suffixIcon: IconButton(
+                        icon: Icon(
+                          _obscureConfirmPassword
+                              ? Icons.visibility_off
+                              : Icons.visibility,
+                        ),
+                        onPressed: () {
+                          setState(() {
+                            _obscureConfirmPassword = !_obscureConfirmPassword;
+                          });
+                        },
+                      ),
+                    ),
+                    obscureText: _obscureConfirmPassword,
+                    validator: (value) {
+                      if (value == null || value.isEmpty) {
+                        return 'Bitte Passwort bestätigen';
+                      }
+                      if (value != _passwordController.text) {
+                        return 'Passwörter stimmen nicht überein';
+                      }
+                      return null;
+                    },
+                  ),
+                  const SizedBox(height: 16),
+                  Row(
+                    children: [
+                      Checkbox(
+                        value: _termsAccepted,
+                        onChanged: (value) {
+                          setState(() {
+                            _termsAccepted = value ?? false;
+                          });
+                        },
+                      ),
+                      Expanded(
+                        child: Wrap(
+                          crossAxisAlignment: WrapCrossAlignment.center,
+                          children: [
+                            const Text('Ich akzeptiere die '),
+                            GestureDetector(
+                              onTap: () {},
+                              child: Text(
+                                'Nutzungsbedingungen',
+                                style: TextStyle(
+                                  color: Theme.of(context).colorScheme.primary,
+                                  decoration: TextDecoration.underline,
+                                ),
+                              ),
+                            ),
+                          ],
+                        ),
+                      ),
+                    ],
+                  ),
+                  const SizedBox(height: 24),
+                  ElevatedButton(
+                    onPressed: isLoading ? null : _validateAndSubmit,
+                    child: isLoading
+                        ? const SizedBox(
+                            width: 24,
+                            height: 24,
+                            child: CircularProgressIndicator(strokeWidth: 2),
+                          )
+                        : const Text('Registrieren'),
+                  ),
+                  TextButton(
+                    onPressed: isLoading ? null : () => context.pop(),
+                    child: const Text('Zurück zum Login'),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        );
+      },
+    );
+  }
+}
+


### PR DESCRIPTION
## Summary
- build registration page with name, role, password confirmation, and terms acceptance
- document register screen completion in roadmap and changelog
- prepare next prompt for registration BLoC events and states

## Testing
- `dart format lib/features/auth/presentation/pages/register_page.dart` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6895747eaf1c832ebaa9e24ae158f3eb