### PR TITLE
feat: add chat message model

### DIFF
--- a/codex/daten/changelog.md
+++ b/codex/daten/changelog.md
@@ -181,3 +181,7 @@
 - `OpenAIService` mit `sendChatRequest` und Exponential Backoff erstellt
 - Service im `service_locator` registriert
 - Roadmap und Prompt aktualisiert
+
+### Phase 1: Chat Message Model und Serialization - 2025-08-08
+- `ChatMessage` Modell mit JSON-Serialisierung und Unterstützung für Text, Bild und Datei-Anhänge erstellt
+- Roadmap aktualisiert

--- a/codex/daten/prompt.md
+++ b/codex/daten/prompt.md
@@ -1,4 +1,4 @@
-# Nächster Schritt: Phase 1 – `Chat Message Model und Serialization`
+# Nächster Schritt: Phase 1 – `AI Prompt Engineering für Sokratische Methode`
 
 ## Status
 - Phase 0 abgeschlossen ✓
@@ -38,6 +38,7 @@
 - Registration API Integration implementiert ✓
 - Password Strength Indicator implementiert ✓
 - OpenAI API Integration Setup implementiert ✓
+- Chat Message Model und Serialization implementiert ✓
 
 ## Referenzen
 - `/README.md`
@@ -45,20 +46,20 @@
 - `/codex/daten/roadmap.md`
 - `/codex/daten/changelog.md`
 
-## Nächste Aufgabe: `Chat Message Model und Serialization`
+## Nächste Aufgabe: `AI Prompt Engineering für Sokratische Methode`
 
 ### Vorbereitungen
 - Navigiere zum Projekt-Root `flutter_app/mrs_unkwn_app`.
 
 ### Implementierungsschritte
-- `lib/features/tutoring/data/models/chat_message.dart` erstellen.
-- Eigenschaften: `id`, `role` (user/assistant/system), `content`, `timestamp`, `metadata`.
-- `@JsonSerializable()` nutzen und `fromJson()` sowie `toJson()` implementieren.
-- Message-Typen: Text, Image, File-Attachment.
-- Threading für Multi-Turn-Konversationen berücksichtigen.
+- `lib/features/tutoring/data/prompts/socratic_prompts.dart` erstellen.
+- System-Prompts für Mathematik, Naturwissenschaften, Literatur und Geschichte definieren.
+- Prompt-Templates implementieren, die sokratisches Fragen fördern.
+- Altersgerechte Varianten und Kontext-Verkettung berücksichtigen.
+- Token-Limits und Kontext-Management beachten.
 
 ### Validierung
-- `dart format lib/features/tutoring/data/models/chat_message.dart`.
+- `dart format lib/features/tutoring/data/prompts/socratic_prompts.dart`.
 - `flutter analyze`.
 
 ### Selbstgenerierung

--- a/codex/daten/roadmap.md
+++ b/codex/daten/roadmap.md
@@ -233,7 +233,7 @@ Details: Optimize Background-Service für Minimal-Battery-Impact using JobSchedu
 [x] OpenAI API Integration Setup:
 Details: Installiere `http` Package für API-Requests. Erstelle `lib/core/services/openai_service.dart`. Implementiere `OpenAIService` Klasse mit API-Key aus Environment-Variables. Create Methods: `sendChatRequest(String message, List<ChatMessage> context)`. Handle API-Rate-Limiting mit Exponential-Backoff-Retry. Implement Request-Timeout-Handling (30 seconds). Store API-Usage-Statistics für Cost-Tracking.
 
-[ ] Chat Message Model und Serialization:
+[x] Chat Message Model und Serialization:
 Details: Erstelle `lib/features/tutoring/data/models/chat_message.dart`. Implementiere `ChatMessage` Model mit Properties: `id`, `role` (user/assistant/system), `content`, `timestamp`, `metadata`. Add `@JsonSerializable()` für Serialization. Implement `fromJson()` und `toJson()` Methods. Create Message-Types: Text, Image, File-Attachment. Handle Message-Threading für Multi-turn-Conversations.
 
 [ ] AI Prompt Engineering für Sokratische Methode:

--- a/flutter_app/mrs_unkwn_app/lib/features/tutoring/data/models/chat_message.dart
+++ b/flutter_app/mrs_unkwn_app/lib/features/tutoring/data/models/chat_message.dart
@@ -1,0 +1,38 @@
+import 'package:json_annotation/json_annotation.dart';
+
+part 'chat_message.g.dart';
+
+enum ChatRole { user, assistant, system }
+
+enum ChatMessageType { text, image, file }
+
+@JsonSerializable()
+class ChatMessage {
+  final String id;
+  final ChatRole role;
+  final ChatMessageType type;
+  final String content;
+  final DateTime timestamp;
+  final Map<String, dynamic>? metadata;
+  final String? attachmentUrl;
+  final String? threadId;
+  final String? parentId;
+
+  const ChatMessage({
+    required this.id,
+    required this.role,
+    required this.type,
+    required this.content,
+    required this.timestamp,
+    this.metadata,
+    this.attachmentUrl,
+    this.threadId,
+    this.parentId,
+  });
+
+  factory ChatMessage.fromJson(Map<String, dynamic> json) =>
+      _$ChatMessageFromJson(json);
+
+  Map<String, dynamic> toJson() => _$ChatMessageToJson(this);
+}
+

--- a/flutter_app/mrs_unkwn_app/lib/features/tutoring/data/models/chat_message.g.dart
+++ b/flutter_app/mrs_unkwn_app/lib/features/tutoring/data/models/chat_message.g.dart
@@ -1,0 +1,39 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'chat_message.dart';
+
+ChatMessage _$ChatMessageFromJson(Map<String, dynamic> json) => ChatMessage(
+      id: json['id'] as String,
+      role: $enumDecode(_$ChatRoleEnumMap, json['role']),
+      type: $enumDecode(_$ChatMessageTypeEnumMap, json['type']),
+      content: json['content'] as String,
+      timestamp: DateTime.parse(json['timestamp'] as String),
+      metadata: json['metadata'] as Map<String, dynamic>?,
+      attachmentUrl: json['attachmentUrl'] as String?,
+      threadId: json['threadId'] as String?,
+      parentId: json['parentId'] as String?,
+    );
+
+Map<String, dynamic> _$ChatMessageToJson(ChatMessage instance) => <String, dynamic>{
+      'id': instance.id,
+      'role': _$ChatRoleEnumMap[instance.role]!,
+      'type': _$ChatMessageTypeEnumMap[instance.type]!,
+      'content': instance.content,
+      'timestamp': instance.timestamp.toIso8601String(),
+      'metadata': instance.metadata,
+      'attachmentUrl': instance.attachmentUrl,
+      'threadId': instance.threadId,
+      'parentId': instance.parentId,
+    };
+
+const Map<ChatRole, String> _$ChatRoleEnumMap = {
+  ChatRole.user: 'user',
+  ChatRole.assistant: 'assistant',
+  ChatRole.system: 'system',
+};
+
+const Map<ChatMessageType, String> _$ChatMessageTypeEnumMap = {
+  ChatMessageType.text: 'text',
+  ChatMessageType.image: 'image',
+  ChatMessageType.file: 'file',
+};


### PR DESCRIPTION
## Summary
- add `ChatMessage` model with JSON serialization and support for attachments
- track completion of chat message model in roadmap, changelog, and prompt

## Testing
- `dart format lib/features/tutoring/data/models/chat_message.dart` *(command not found)*
- `flutter analyze` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689588679ff4832ea8c66577ae360d19