### PR TITLE
feat: add socratic prompts

### DIFF
--- a/codex/daten/changelog.md
+++ b/codex/daten/changelog.md
@@ -185,3 +185,8 @@
 ### Phase 1: Chat Message Model und Serialization - 2025-08-08
 - `ChatMessage` Modell mit JSON-Serialisierung und Unterstützung für Text, Bild und Datei-Anhänge erstellt
 - Roadmap aktualisiert
+
+### Phase 1: AI Prompt Engineering für Sokratische Methode - 2025-08-08
+- `socratic_prompts.dart` mit fachspezifischen, altersgerechten System-Prompts erstellt
+- Kontext- und Tokenlimit-Management für Gesprächsverläufe implementiert
+- Roadmap aktualisiert

--- a/codex/daten/prompt.md
+++ b/codex/daten/prompt.md
@@ -1,4 +1,4 @@
-# Nächster Schritt: Phase 1 – `AI Prompt Engineering für Sokratische Methode`
+# Nächster Schritt: Phase 1 – `Chat UI Interface Implementation`
 
 ## Status
 - Phase 0 abgeschlossen ✓
@@ -39,6 +39,7 @@
 - Password Strength Indicator implementiert ✓
 - OpenAI API Integration Setup implementiert ✓
 - Chat Message Model und Serialization implementiert ✓
+- AI Prompt Engineering für Sokratische Methode implementiert ✓
 
 ## Referenzen
 - `/README.md`
@@ -46,20 +47,21 @@
 - `/codex/daten/roadmap.md`
 - `/codex/daten/changelog.md`
 
-## Nächste Aufgabe: `AI Prompt Engineering für Sokratische Methode`
+## Nächste Aufgabe: `Chat UI Interface Implementation`
 
 ### Vorbereitungen
 - Navigiere zum Projekt-Root `flutter_app/mrs_unkwn_app`.
 
 ### Implementierungsschritte
-- `lib/features/tutoring/data/prompts/socratic_prompts.dart` erstellen.
-- System-Prompts für Mathematik, Naturwissenschaften, Literatur und Geschichte definieren.
-- Prompt-Templates implementieren, die sokratisches Fragen fördern.
-- Altersgerechte Varianten und Kontext-Verkettung berücksichtigen.
-- Token-Limits und Kontext-Management beachten.
+- `lib/features/tutoring/presentation/pages/chat_page.dart` erstellen.
+- Chat-Bubble-UI mit Sender-Differenzierung (Student vs AI) implementieren.
+- Message-Input-Field mit Send-Button und Voice-Option hinzufügen.
+- Auto-Scroll zu neuesten Nachrichten und Load-More-History implementieren.
+- Typing-Indicator während AI-Antwort generieren.
+- Nachrichtenzustände (Sending, Sent, Error) visuell darstellen.
 
 ### Validierung
-- `dart format lib/features/tutoring/data/prompts/socratic_prompts.dart`.
+- `dart format lib/features/tutoring/presentation/pages/chat_page.dart`.
 - `flutter analyze`.
 
 ### Selbstgenerierung

--- a/codex/daten/roadmap.md
+++ b/codex/daten/roadmap.md
@@ -236,7 +236,7 @@ Details: Installiere `http` Package für API-Requests. Erstelle `lib/core/servic
 [x] Chat Message Model und Serialization:
 Details: Erstelle `lib/features/tutoring/data/models/chat_message.dart`. Implementiere `ChatMessage` Model mit Properties: `id`, `role` (user/assistant/system), `content`, `timestamp`, `metadata`. Add `@JsonSerializable()` für Serialization. Implement `fromJson()` und `toJson()` Methods. Create Message-Types: Text, Image, File-Attachment. Handle Message-Threading für Multi-turn-Conversations.
 
-[ ] AI Prompt Engineering für Sokratische Methode:
+[x] AI Prompt Engineering für Sokratische Methode:
 Details: Erstelle `lib/features/tutoring/data/prompts/socratic_prompts.dart`. Define System-Prompts für verschiedene Subjects: Math, Science, Literature, History. Implement Prompt-Templates die Socratic-Questioning fördern: "Instead of giving the answer, ask a guiding question". Create Age-appropriate-Prompts für Different-Grade-Levels. Implement Context-Building für Previous-Conversation-History. Handle Prompt-Length-Limits und Token-Management.
 
 [ ] Chat UI Interface Implementation:

--- a/flutter_app/mrs_unkwn_app/lib/features/tutoring/data/prompts/socratic_prompts.dart
+++ b/flutter_app/mrs_unkwn_app/lib/features/tutoring/data/prompts/socratic_prompts.dart
@@ -1,0 +1,65 @@
+import '../models/chat_message.dart';
+
+/// Subjects supported by the tutoring module.
+enum TutoringSubject { math, science, literature, history }
+
+/// Generates subject specific prompts that enforce the Socratic method.
+class SocraticPrompts {
+  static const Map<TutoringSubject, String> _systemPrompts = {
+    TutoringSubject.math:
+        'You are a Socratic math tutor for a {age}-year-old student. Ask short guiding questions that help the learner derive the solution step by step without giving the answer.',
+    TutoringSubject.science:
+        'You are a Socratic science tutor for a {age}-year-old student. Encourage curiosity by asking questions that lead to scientific reasoning and experimentation rather than stating facts.',
+    TutoringSubject.literature:
+        'You are a Socratic literature tutor for a {age}-year-old student. Explore themes, characters and the author\'s intent through probing questions instead of direct explanations.',
+    TutoringSubject.history:
+        'You are a Socratic history tutor for a {age}-year-old student. Guide the learner with questions that connect causes and consequences without recounting events outright.'
+  };
+
+  /// Returns the system prompt for the given [subject] and [age].
+  static String systemPrompt(TutoringSubject subject, {required int age}) {
+    return _systemPrompts[subject]!.replaceAll('{age}', age.toString());
+  }
+
+  /// Builds a full prompt including previous [history] and the current [question].
+  ///
+  /// [maxContextTokens] limits how many tokens from the conversation history are
+  /// kept to stay within model limits.
+  static String buildPrompt({
+    required TutoringSubject subject,
+    required int age,
+    required List<ChatMessage> history,
+    required String question,
+    int maxContextTokens = 800,
+  }) {
+    final buffer = StringBuffer(systemPrompt(subject, age: age));
+    final trimmed = _trimHistory(history, maxContextTokens);
+    for (final msg in trimmed) {
+      final speaker = msg.role == ChatRole.user ? 'Student' : 'Tutor';
+      buffer.writeln('$speaker: ${msg.content}');
+    }
+    buffer.writeln('Student: $question');
+    buffer.writeln('Tutor:');
+    return buffer.toString();
+  }
+
+  /// Trims conversation [history] to respect [maxTokens] using a simple word
+  /// count as token approximation.
+  static List<ChatMessage> _trimHistory(
+      List<ChatMessage> history, int maxTokens) {
+    final List<ChatMessage> result = [];
+    int tokenCount = 0;
+    for (final msg in history.reversed) {
+      final tokens = _countTokens(msg.content);
+      if (tokenCount + tokens > maxTokens) break;
+      result.add(msg);
+      tokenCount += tokens;
+    }
+    return result.reversed.toList();
+  }
+
+  /// Naively counts tokens by splitting on whitespace.
+  static int _countTokens(String text) {
+    return text.trim().isEmpty ? 0 : text.split(RegExp(r'\s+')).length;
+  }
+}


### PR DESCRIPTION
## Summary
- add subject-specific socratic prompts with context trimming
- update roadmap and changelog
- prepare next prompt for chat UI implementation

## Testing
- `dart format lib/features/tutoring/data/prompts/socratic_prompts.dart` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68958c62c69c832eb40e05a8d553729d