### PR TITLE
feat: add AI response generation service

### DIFF
--- a/codex/daten/changelog.md
+++ b/codex/daten/changelog.md
@@ -195,3 +195,8 @@
 - `chat_page.dart` mit Chat-Bubbles, Eingabefeld, Auto-Scroll und Typing-Indikator erstellt
 - Statusanzeigen für Nachrichten (Sending, Sent, Error) umgesetzt
 - `dart format` und `flutter analyze` ausgeführt (Werkzeuge nicht verfügbar)
+
+### Phase 1: AI Response Generation Service - 2025-08-08
+- `AIResponseService` mit Streaming-Ausgabe, Content-Filterung und Response-Caching erstellt
+- Service im `service_locator` registriert
+- Roadmap aktualisiert

--- a/codex/daten/prompt.md
+++ b/codex/daten/prompt.md
@@ -1,4 +1,4 @@
-# Nächster Schritt: Phase 1 – `AI Response Generation Service`
+# Nächster Schritt: Phase 1 – `Subject Classification System`
 
 ## Status
 - Phase 0 abgeschlossen ✓
@@ -41,6 +41,7 @@
 - Chat Message Model und Serialization implementiert ✓
 - AI Prompt Engineering für Sokratische Methode implementiert ✓
 - Chat UI Interface Implementation implementiert ✓
+- AI Response Generation Service implementiert ✓
 
 ## Referenzen
 - `/README.md`
@@ -48,21 +49,20 @@
 - `/codex/daten/roadmap.md`
 - `/codex/daten/changelog.md`
 
-## Nächste Aufgabe: `AI Response Generation Service`
+## Nächste Aufgabe: `Subject Classification System`
 
 ### Vorbereitungen
 - Navigiere zum Projekt-Root `flutter_app/mrs_unkwn_app`.
 
 ### Implementierungsschritte
-- `lib/features/tutoring/data/services/ai_response_service.dart` erstellen.
-- OpenAI-API-Requests mit Gesprächskontext und System-Prompts aufbauen.
-- Streaming-Responses für Echtzeit-Anzeige handhaben.
-- Content-Filtering für unangemessene Antworten implementieren.
-- Response-Caching für ähnliche Fragen hinzufügen.
-- Benutzerfreundliche Fehlerbehandlung integrieren.
+- `lib/features/tutoring/data/services/subject_classification_service.dart` erstellen.
+- Schlüsselwortbasierte Fachklassifikation implementieren.
+- Platzhalter für ML-basierte Klassifikation einfügen.
+- Subject-History-Tracking vorbereiten.
+- Multi-Subject-Fragen und Fachwechsel behandeln.
 
 ### Validierung
-- `dart format lib/features/tutoring/data/services/ai_response_service.dart`.
+- `dart format lib/features/tutoring/data/services/subject_classification_service.dart`.
 - `flutter analyze`.
 
 ### Selbstgenerierung

--- a/codex/daten/roadmap.md
+++ b/codex/daten/roadmap.md
@@ -242,7 +242,7 @@ Details: Erstelle `lib/features/tutoring/data/prompts/socratic_prompts.dart`. De
 [x] Chat UI Interface Implementation:
 Details: Erstelle `lib/features/tutoring/presentation/pages/chat_page.dart`. Implementiere Chat-Bubble-UI mit Sender-Differentiation (Student vs AI). Create Message-Input-Field mit Send-Button und Voice-Input-Option. Implement Auto-Scroll zu newest Messages und Load-More-History. Add Typing-Indicators during AI-Response-Generation. Handle Message-Delivery-Status (Sending, Sent, Error) mit Visual-Indicators.
 
-[ ] AI Response Generation Service:
+[x] AI Response Generation Service:
 Details: Erstelle `ai_response_service.dart` der OpenAI-API-Calls managed. Implement Request-Building mit Conversation-Context und System-Prompts. Handle Streaming-Responses für Real-time-Message-Display. Implement Content-Filtering für Inappropriate-AI-Responses. Add Response-Caching für Similar-Questions. Handle API-Errors gracefully mit User-friendly-Error-Messages.
 
 [ ] Subject Classification System:

--- a/flutter_app/mrs_unkwn_app/lib/core/di/service_locator.dart
+++ b/flutter_app/mrs_unkwn_app/lib/core/di/service_locator.dart
@@ -1,5 +1,6 @@
 import 'package:get_it/get_it.dart';
 import '../services/openai_service.dart';
+import '../../features/tutoring/data/services/ai_response_service.dart';
 
 final sl = GetIt.instance;
 
@@ -15,6 +16,9 @@ void _registerCore() {
 
 void _registerFeatures() {
   // Register feature-specific services here
+  sl.registerLazySingleton<AIResponseService>(
+    () => AIResponseService(openAI: sl()),
+  );
 }
 
 void _registerExternal() {

--- a/flutter_app/mrs_unkwn_app/lib/features/tutoring/data/services/ai_response_service.dart
+++ b/flutter_app/mrs_unkwn_app/lib/features/tutoring/data/services/ai_response_service.dart
@@ -1,0 +1,88 @@
+import 'dart:async';
+
+import '../../../../core/services/openai_service.dart' as oai;
+import '../models/chat_message.dart';
+import '../prompts/socratic_prompts.dart';
+
+/// Service responsible for generating AI tutoring responses.
+class AIResponseService {
+  AIResponseService({oai.OpenAIService? openAI, Duration? streamDelay})
+      : _openAI = openAI ?? oai.OpenAIService(),
+        _delay = streamDelay ?? const Duration(milliseconds: 50);
+
+  final oai.OpenAIService _openAI;
+  final Duration _delay;
+  final Map<String, String> _cache = {};
+
+  static const Set<String> _bannedKeywords = {
+    'violence',
+    'suicide',
+    'kill',
+    'hate',
+  };
+
+  /// Generates a response stream for the given [question].
+  ///
+  /// [history] holds previous chat messages.
+  /// [subject] and [age] build the system prompt.
+  Stream<String> generateResponse({
+    required List<ChatMessage> history,
+    required String question,
+    required TutoringSubject subject,
+    required int age,
+  }) async* {
+    final cacheKey = '${subject.name}::$question';
+    if (_cache.containsKey(cacheKey)) {
+      yield _cache[cacheKey]!;
+      return;
+    }
+
+    final context = [
+      oai.ChatMessage(
+        role: 'system',
+        content: SocraticPrompts.systemPrompt(subject, age: age),
+      ),
+      ...history.map(
+        (m) => oai.ChatMessage(role: _mapRole(m.role), content: m.content),
+      ),
+    ];
+
+    String response;
+    try {
+      response = await _openAI.sendChatRequest(question, context);
+    } catch (_) {
+      yield 'Oops, something went wrong. Please try again.';
+      return;
+    }
+
+    if (_containsBannedContent(response)) {
+      yield 'I\'m sorry, but I can\'t help with that.';
+      return;
+    }
+
+    _cache[cacheKey] = response;
+
+    final parts = response.split(RegExp(r'\s+'));
+    for (final part in parts) {
+      yield part;
+      await Future.delayed(_delay);
+    }
+  }
+
+  bool _containsBannedContent(String text) {
+    final lower = text.toLowerCase();
+    return _bannedKeywords.any(lower.contains);
+  }
+
+  String _mapRole(ChatRole role) {
+    switch (role) {
+      case ChatRole.user:
+        return 'user';
+      case ChatRole.assistant:
+        return 'assistant';
+      case ChatRole.system:
+        return 'system';
+    }
+  }
+}
+


### PR DESCRIPTION
## Summary
- implement `AIResponseService` for streaming tutoring replies with filtering and caching
- register service in dependency injection
- document progress and update roadmap/prompt

## Testing
- `dart format lib/features/tutoring/data/services/ai_response_service.dart` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68959459c43c832e991c2517e265b755