### PR TITLE
feat: add subject classification service

### DIFF
--- a/codex/daten/changelog.md
+++ b/codex/daten/changelog.md
@@ -200,3 +200,8 @@
 - `AIResponseService` mit Streaming-Ausgabe, Content-Filterung und Response-Caching erstellt
 - Service im `service_locator` registriert
 - Roadmap aktualisiert
+
+### Phase 1: Subject Classification System - 2025-08-08
+- `SubjectClassificationService` mit Schlüsselwort-basierter Klassifikation und Fachwechsel-Erkennung erstellt
+- Historien-Tracking vorbereitet und Platzhalter für ML-basierte Klassifikation hinzugefügt
+- Service im `service_locator` registriert, Roadmap und Prompt aktualisiert

--- a/codex/daten/prompt.md
+++ b/codex/daten/prompt.md
@@ -1,4 +1,4 @@
-# Nächster Schritt: Phase 1 – `Subject Classification System`
+# Nächster Schritt: Phase 1 – `Learning Session Management`
 
 ## Status
 - Phase 0 abgeschlossen ✓
@@ -42,6 +42,7 @@
 - AI Prompt Engineering für Sokratische Methode implementiert ✓
 - Chat UI Interface Implementation implementiert ✓
 - AI Response Generation Service implementiert ✓
+- Subject Classification System implementiert ✓
 
 ## Referenzen
 - `/README.md`
@@ -49,20 +50,20 @@
 - `/codex/daten/roadmap.md`
 - `/codex/daten/changelog.md`
 
-## Nächste Aufgabe: `Subject Classification System`
+## Nächste Aufgabe: `Learning Session Management`
 
 ### Vorbereitungen
 - Navigiere zum Projekt-Root `flutter_app/mrs_unkwn_app`.
 
 ### Implementierungsschritte
-- `lib/features/tutoring/data/services/subject_classification_service.dart` erstellen.
-- Schlüsselwortbasierte Fachklassifikation implementieren.
-- Platzhalter für ML-basierte Klassifikation einfügen.
-- Subject-History-Tracking vorbereiten.
-- Multi-Subject-Fragen und Fachwechsel behandeln.
+- `lib/features/tutoring/data/models/learning_session.dart` erstellen.
+- Session-Start/End-Logik mit Duration-Berechnung implementieren.
+- Metriken wie Fragenanzahl, Themen und AI-Interaktionen verfolgen.
+- Speicherung in lokaler Datenbank vorbereiten.
+- Platzhalter für Backend-Sync und Wiederaufnahme von Sessions einfügen.
 
 ### Validierung
-- `dart format lib/features/tutoring/data/services/subject_classification_service.dart`.
+- `dart format lib/features/tutoring/data/models/learning_session.dart`.
 - `flutter analyze`.
 
 ### Selbstgenerierung

--- a/codex/daten/roadmap.md
+++ b/codex/daten/roadmap.md
@@ -245,7 +245,7 @@ Details: Erstelle `lib/features/tutoring/presentation/pages/chat_page.dart`. Imp
 [x] AI Response Generation Service:
 Details: Erstelle `ai_response_service.dart` der OpenAI-API-Calls managed. Implement Request-Building mit Conversation-Context und System-Prompts. Handle Streaming-Responses für Real-time-Message-Display. Implement Content-Filtering für Inappropriate-AI-Responses. Add Response-Caching für Similar-Questions. Handle API-Errors gracefully mit User-friendly-Error-Messages.
 
-[ ] Subject Classification System:
+[x] Subject Classification System:
 Details: Implementiere Subject-Detection-Algorithm für Student-Questions. Create Keyword-Based-Classification für Basic-Subject-Detection: Math-Keywords (equation, solve, calculate), Science-Keywords (experiment, hypothesis), etc. Implement Machine-Learning-Classification für Better-Accuracy. Store Subject-History für Learning-Analytics. Handle Multi-Subject-Questions und Subject-Switching in Conversations.
 
 [ ] Learning Session Management:

--- a/flutter_app/mrs_unkwn_app/lib/core/di/service_locator.dart
+++ b/flutter_app/mrs_unkwn_app/lib/core/di/service_locator.dart
@@ -1,6 +1,7 @@
 import 'package:get_it/get_it.dart';
 import '../services/openai_service.dart';
 import '../../features/tutoring/data/services/ai_response_service.dart';
+import '../../features/tutoring/data/services/subject_classification_service.dart';
 
 final sl = GetIt.instance;
 
@@ -18,6 +19,9 @@ void _registerFeatures() {
   // Register feature-specific services here
   sl.registerLazySingleton<AIResponseService>(
     () => AIResponseService(openAI: sl()),
+  );
+  sl.registerLazySingleton<SubjectClassificationService>(
+    () => SubjectClassificationService(),
   );
 }
 

--- a/flutter_app/mrs_unkwn_app/lib/features/tutoring/data/services/subject_classification_service.dart
+++ b/flutter_app/mrs_unkwn_app/lib/features/tutoring/data/services/subject_classification_service.dart
@@ -1,0 +1,113 @@
+import 'dart:collection';
+
+/// Service for determining the subject of a user question.
+/// Uses simple keyword matching and keeps a history of
+/// detected subjects. A placeholder for a future
+/// ML-based classifier is provided.
+class SubjectClassificationService {
+  SubjectClassificationService();
+
+  final Map<String, List<String>> _keywordMap = {
+    'math': [
+      'math',
+      'equation',
+      'calculate',
+      'geometry',
+      'algebra',
+      'fraction',
+      'integral',
+      'derivative',
+    ],
+    'science': [
+      'science',
+      'experiment',
+      'physics',
+      'chemistry',
+      'biology',
+      'hypothesis',
+      'atom',
+      'cell',
+    ],
+    'literature': [
+      'literature',
+      'poem',
+      'novel',
+      'author',
+      'story',
+      'character',
+      'plot',
+    ],
+    'history': [
+      'history',
+      'war',
+      'revolution',
+      'ancient',
+      'empire',
+      'president',
+      'king',
+    ],
+  };
+
+  final List<String> _history = [];
+  String? _currentSubject;
+  bool _subjectSwitched = false;
+
+  /// Classifies the given [question] and returns a list of
+  /// detected subjects. Multiple subjects may be returned
+  /// for multi-topic questions.
+  List<String> classify(String question) {
+    final lower = question.toLowerCase();
+    final Set<String> subjects = {};
+
+    _keywordMap.forEach((subject, keywords) {
+      for (final keyword in keywords) {
+        if (lower.contains(keyword)) {
+          subjects.add(subject);
+          break;
+        }
+      }
+    });
+
+    if (subjects.isEmpty) {
+      subjects.add('unknown');
+    }
+
+    final result = subjects.toList();
+    _handleSubjectSwitch(result);
+    _updateHistory(result);
+    return result;
+  }
+
+  void _handleSubjectSwitch(List<String> subjects) {
+    _subjectSwitched = false;
+    if (subjects.length == 1) {
+      final newSubject = subjects.first;
+      if (_currentSubject != null && _currentSubject != newSubject) {
+        _subjectSwitched = true;
+      }
+      _currentSubject = newSubject;
+    } else {
+      _currentSubject = null;
+    }
+  }
+
+  void _updateHistory(List<String> subjects) {
+    _history.addAll(subjects);
+  }
+
+  /// Returns an unmodifiable view of the classification history.
+  List<String> get history => UnmodifiableListView(_history);
+
+  /// Indicates whether the last classification detected a
+  /// switch in subject compared to the previous single-subject
+  /// classification.
+  bool get subjectSwitched => _subjectSwitched;
+
+  /// Placeholder for future ML-based classification.
+  /// Currently falls back to [classify].
+  Future<List<String>> classifyWithModel(String question) async {
+    // TODO: Replace with model inference when available.
+    return classify(question);
+  }
+}
+


### PR DESCRIPTION
## Summary
- add keyword-based SubjectClassificationService with history tracking and subject switch detection
- register subject classification service in GetIt service locator
- document completion in roadmap, changelog and advance prompt to Learning Session Management

## Testing
- `dart format lib/features/tutoring/data/services/subject_classification_service.dart` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689598550710832e9803f2e3f5e5e971