### PR TITLE
feat: add learning session model

### DIFF
--- a/codex/daten/changelog.md
+++ b/codex/daten/changelog.md
@@ -205,3 +205,9 @@
 - `SubjectClassificationService` mit Schlüsselwort-basierter Klassifikation und Fachwechsel-Erkennung erstellt
 - Historien-Tracking vorbereitet und Platzhalter für ML-basierte Klassifikation hinzugefügt
 - Service im `service_locator` registriert, Roadmap und Prompt aktualisiert
+
+### Phase 1: Learning Session Management - 2025-08-08
+- `LearningSession` Modell mit Start/End-Logik und Dauerberechnung erstellt
+- Metriken für Fragen, Themen und AI-Interaktionen hinzugefügt
+- Platzhalter für lokale Speicherung und Backend-Sync implementiert
+- Roadmap und Prompt aktualisiert

--- a/codex/daten/prompt.md
+++ b/codex/daten/prompt.md
@@ -1,4 +1,4 @@
-# Nächster Schritt: Phase 1 – `Learning Session Management`
+# Nächster Schritt: Phase 1 – `AI Tutoring BLoC State Management`
 
 ## Status
 - Phase 0 abgeschlossen ✓
@@ -43,6 +43,7 @@
 - Chat UI Interface Implementation implementiert ✓
 - AI Response Generation Service implementiert ✓
 - Subject Classification System implementiert ✓
+- Learning Session Management implementiert ✓
 
 ## Referenzen
 - `/README.md`
@@ -50,20 +51,20 @@
 - `/codex/daten/roadmap.md`
 - `/codex/daten/changelog.md`
 
-## Nächste Aufgabe: `Learning Session Management`
+## Nächste Aufgabe: `AI Tutoring BLoC State Management`
 
 ### Vorbereitungen
 - Navigiere zum Projekt-Root `flutter_app/mrs_unkwn_app`.
 
 ### Implementierungsschritte
-- `lib/features/tutoring/data/models/learning_session.dart` erstellen.
-- Session-Start/End-Logik mit Duration-Berechnung implementieren.
-- Metriken wie Fragenanzahl, Themen und AI-Interaktionen verfolgen.
-- Speicherung in lokaler Datenbank vorbereiten.
-- Platzhalter für Backend-Sync und Wiederaufnahme von Sessions einfügen.
+- `lib/features/tutoring/presentation/bloc/tutoring_bloc.dart` erstellen.
+- Events: `SendMessageRequested`, `LoadChatHistoryRequested`, `StartLearningSessionRequested`, `EndLearningSessionRequested`.
+- States: `TutoringInitial`, `TutoringLoading`, `MessagesLoaded`, `MessageSent`, `TutoringError`.
+- Event-Handler implementieren mit AI-API-Integration und lokalem Datenmanagement.
+- Optimistische UI-Updates für bessere User Experience umsetzen.
 
 ### Validierung
-- `dart format lib/features/tutoring/data/models/learning_session.dart`.
+- `dart format lib/features/tutoring/presentation/bloc/tutoring_bloc.dart`.
 - `flutter analyze`.
 
 ### Selbstgenerierung

--- a/codex/daten/roadmap.md
+++ b/codex/daten/roadmap.md
@@ -248,7 +248,7 @@ Details: Erstelle `ai_response_service.dart` der OpenAI-API-Calls managed. Imple
 [x] Subject Classification System:
 Details: Implementiere Subject-Detection-Algorithm für Student-Questions. Create Keyword-Based-Classification für Basic-Subject-Detection: Math-Keywords (equation, solve, calculate), Science-Keywords (experiment, hypothesis), etc. Implement Machine-Learning-Classification für Better-Accuracy. Store Subject-History für Learning-Analytics. Handle Multi-Subject-Questions und Subject-Switching in Conversations.
 
-[ ] Learning Session Management:
+[x] Learning Session Management:
 Details: Erstelle `learning_session.dart` Model für Session-Tracking. Implement Session-Start/End-Logic mit Duration-Calculation. Track Learning-Metrics: Questions-Asked, Topics-Covered, AI-Interactions-Count. Store Session-Data in Local-Database mit Sync-to-Backend. Implement Session-Goals und Progress-Tracking. Handle Session-Interruptions und Resume-Functionality.
 
 [ ] AI Tutoring BLoC State Management:

--- a/flutter_app/mrs_unkwn_app/lib/features/tutoring/data/models/learning_session.dart
+++ b/flutter_app/mrs_unkwn_app/lib/features/tutoring/data/models/learning_session.dart
@@ -1,0 +1,83 @@
+import 'package:json_annotation/json_annotation.dart';
+
+part 'learning_session.g.dart';
+
+@JsonSerializable()
+class LearningSession {
+  final String id;
+  final DateTime startedAt;
+  final DateTime? endedAt;
+  @JsonKey(defaultValue: 0)
+  final int questionCount;
+  @JsonKey(defaultValue: [])
+  final List<String> topics;
+  @JsonKey(defaultValue: 0)
+  final int aiInteractions;
+  @JsonKey(defaultValue: false)
+  final bool isSynced;
+  @JsonKey(defaultValue: false)
+  final bool resumed;
+
+  const LearningSession({
+    required this.id,
+    required this.startedAt,
+    this.endedAt,
+    this.questionCount = 0,
+    this.topics = const [],
+    this.aiInteractions = 0,
+    this.isSynced = false,
+    this.resumed = false,
+  });
+
+  factory LearningSession.start() => LearningSession(
+        id: DateTime.now().millisecondsSinceEpoch.toString(),
+        startedAt: DateTime.now(),
+      );
+
+  LearningSession end() => copyWith(endedAt: DateTime.now());
+
+  Duration get duration => (endedAt ?? DateTime.now()).difference(startedAt);
+
+  LearningSession incrementQuestion({String? topic}) {
+    final updatedTopics = List<String>.from(topics);
+    if (topic != null && topic.isNotEmpty && !updatedTopics.contains(topic)) {
+      updatedTopics.add(topic);
+    }
+    return copyWith(
+      questionCount: questionCount + 1,
+      topics: updatedTopics,
+    );
+  }
+
+  LearningSession incrementAiInteractions() =>
+      copyWith(aiInteractions: aiInteractions + 1);
+
+  LearningSession markSynced() => copyWith(isSynced: true);
+
+  LearningSession copyWith({
+    String? id,
+    DateTime? startedAt,
+    DateTime? endedAt,
+    int? questionCount,
+    List<String>? topics,
+    int? aiInteractions,
+    bool? isSynced,
+    bool? resumed,
+  }) =>
+      LearningSession(
+        id: id ?? this.id,
+        startedAt: startedAt ?? this.startedAt,
+        endedAt: endedAt ?? this.endedAt,
+        questionCount: questionCount ?? this.questionCount,
+        topics: topics ?? this.topics,
+        aiInteractions: aiInteractions ?? this.aiInteractions,
+        isSynced: isSynced ?? this.isSynced,
+        resumed: resumed ?? this.resumed,
+      );
+
+  factory LearningSession.fromJson(Map<String, dynamic> json) =>
+      _$LearningSessionFromJson(json);
+
+  Map<String, dynamic> toJson() => _$LearningSessionToJson(this);
+}
+

--- a/flutter_app/mrs_unkwn_app/lib/features/tutoring/data/models/learning_session.g.dart
+++ b/flutter_app/mrs_unkwn_app/lib/features/tutoring/data/models/learning_session.g.dart
@@ -1,0 +1,33 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'learning_session.dart';
+
+LearningSession _$LearningSessionFromJson(Map<String, dynamic> json) =>
+    LearningSession(
+      id: json['id'] as String,
+      startedAt: DateTime.parse(json['startedAt'] as String),
+      endedAt: json['endedAt'] == null
+          ? null
+          : DateTime.parse(json['endedAt'] as String),
+      questionCount: json['questionCount'] as int? ?? 0,
+      topics: (json['topics'] as List<dynamic>?)
+              ?.map((e) => e as String)
+              .toList() ??
+          const [],
+      aiInteractions: json['aiInteractions'] as int? ?? 0,
+      isSynced: json['isSynced'] as bool? ?? false,
+      resumed: json['resumed'] as bool? ?? false,
+    );
+
+Map<String, dynamic> _$LearningSessionToJson(LearningSession instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'startedAt': instance.startedAt.toIso8601String(),
+      'endedAt': instance.endedAt?.toIso8601String(),
+      'questionCount': instance.questionCount,
+      'topics': instance.topics,
+      'aiInteractions': instance.aiInteractions,
+      'isSynced': instance.isSynced,
+      'resumed': instance.resumed,
+    };
+


### PR DESCRIPTION
## Summary
- add `LearningSession` model for tracking tutoring session duration, metrics, and sync state
- document learning session management completion and schedule BLoC state management next
- mark roadmap task complete

## Testing
- `dart format flutter_app/mrs_unkwn_app/lib/features/tutoring/data/models/learning_session.dart` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68959c50b154832e8f906fb250c6500f