### PR TITLE
docs: add manual testing procedures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ __pycache__/
 .idea/
 .vscode/
 .DS_Store
+
+# Manual testing generated files
+codex/tests/manual/generated/

--- a/codex/daten/changelog.md
+++ b/codex/daten/changelog.md
@@ -283,3 +283,7 @@
 - GitHub Actions Workflow `flutter_ci.yml` mit Testmatrix für mehrere Flutter-Versionen und Plattformen hinzugefügt
 - Retry-Logik für flackernde Tests sowie Coverage-Upload zu Codecov implementiert
 - Artefakt-Upload und Fehlbenachrichtigung bei Testfehlschlägen konfiguriert
+### Phase 1: Manual Testing Procedures - 2025-08-08
+- Verzeichnis `codex/tests/manual` mit Checklisten, UAT-Szenarien, Beta-Programm, Bug-Reporting, Usability-Plan sowie Qualitäts-Gates erstellt
+- Skript `scripts/generate_manual_testing_assets.sh` generiert CSV-Vorlagen für Checkliste und Bug-Reports
+- Roadmap und Prompt aktualisiert

--- a/codex/daten/prompt.md
+++ b/codex/daten/prompt.md
@@ -1,4 +1,4 @@
-# Nächster Schritt: Phase 1 – `Manual Testing Procedures`
+# Nächster Schritt: Phase 1 – `Monitoring und Crash Reporting`
 
 ## Status
 - Phase 0 abgeschlossen ✓
@@ -57,6 +57,7 @@
 - Performance Testing und Profiling implementiert ✓
 - Security Testing Implementation implementiert ✓
 - Automated Testing in CI/CD implementiert ✓
+- Manual Testing Procedures implementiert ✓
 
 ## Referenzen
 - `/README.md`
@@ -64,19 +65,19 @@
 - `/codex/daten/roadmap.md`
 - `/codex/daten/changelog.md`
 
-## Nächste Aufgabe: `Manual Testing Procedures`
+## Nächste Aufgabe: `Monitoring und Crash Reporting`
 
 
 ### Vorbereitungen
-- Relevante Dokumentationsordner für Testprozeduren vorbereiten.
+- Projekt für Monitoring- und Crash-Reporting vorbereiten.
 
 ### Implementierungsschritte
-- Manuelle Test-Checklisten für jede Release erstellen.
-- User-Acceptance-Testing-Szenarien mit realen Nutzungsmustern definieren.
-- Beta-Testprogramm mit Family-Testern aufsetzen.
-- Bug-Reporting-Vorlagen und Issue-Tracking-Prozesse erstellen.
-- Usability-Testing-Sessions mit Zielgruppen vorbereiten.
-- Testprozeduren und Quality-Gates dokumentieren.
+- Firebase Crashlytics für Produktionsberichte integrieren.
+- Custom-Error-Tracking für Business-Logik implementieren.
+- Performance-Monitoring mit Firebase Performance oder Sentry aktivieren.
+- Fehlerwarnungen für kritische Produktionsprobleme einrichten.
+- Dashboard zur Fehleranalyse bereitstellen.
+- Mechanismus zur Nutzerfeedback-Sammlung implementieren.
 
 ### Validierung
 - `dart format` auf geänderten Dateien ausführen.

--- a/codex/daten/roadmap.md
+++ b/codex/daten/roadmap.md
@@ -292,7 +292,7 @@ Details: Test API-Security: Authentication-Bypass-Attempts, Token-Validation, In
 [x] Automated Testing in CI/CD:
 Details: Configure GitHub-Actions-Workflow für Automated-Testing. Setup Test-Matrix für Multiple-Flutter-Versions und Platform-Targets. Implement Parallel-Test-Execution für Faster-CI-Runs. Configure Test-Reporting und Coverage-Upload to Codecov. Setup Failure-Notifications und Test-Result-Artifacts. Implement Test-Retry-Logic für Flaky-Tests.
 
-[ ] Manual Testing Procedures:
+[x] Manual Testing Procedures:
 Details: Create Manual-Testing-Checklists für Each-Release. Define User-Acceptance-Testing-Scenarios mit Real-World-Usage-Patterns. Setup Beta-Testing-Program mit Family-Testers. Create Bug-Reporting-Templates und Issue-Tracking-Procedures. Implement Usability-Testing-Sessions mit Target-Demographics. Document Testing-Procedures und Quality-Gates.
 
 [ ] Monitoring und Crash Reporting:

--- a/codex/tests/manual/beta_test_program.md
+++ b/codex/tests/manual/beta_test_program.md
@@ -1,0 +1,12 @@
+# Beta Test Program
+
+This program engages families to test pre-release builds.
+
+## Phases
+1. **Invitation:** Recruit parents and students matching target demographics.
+2. **Onboarding:** Provide installation guides and NDA if required.
+3. **Testing:** Testers execute checklist and UAT scenarios.
+4. **Feedback:** Collect reports via bug template and surveys.
+5. **Closure:** Thank participants and summarize insights.
+
+Maintain a registry of testers and feedback for future releases.

--- a/codex/tests/manual/bug_report_template.md
+++ b/codex/tests/manual/bug_report_template.md
@@ -1,0 +1,31 @@
+# Bug Report Template
+
+```markdown
+### Summary
+<brief description>
+
+### Steps to Reproduce
+1. 
+2. 
+3. 
+
+### Expected Result
+...
+
+### Actual Result
+...
+
+### Environment
+- App version:
+- Device:
+- OS:
+
+### Additional Info
+...
+```
+
+## Issue Tracking Process
+1. Submit bug using the template via issue tracker.
+2. Product owner triages and prioritizes weekly.
+3. Assigned developers fix and reference issue ID in commits.
+4. QA verifies and closes the issue after retest.

--- a/codex/tests/manual/manual_test_checklist_template.md
+++ b/codex/tests/manual/manual_test_checklist_template.md
@@ -1,0 +1,12 @@
+# Manual Testing Checklist Template
+
+This checklist is copied for each release to verify core user flows.
+
+| Test Area | Test | Status | Notes |
+|-----------|------|--------|-------|
+| Login | Login with valid credentials | ☐ | |
+| Registration | Register a new user | ☐ | |
+| Tutoring | Start a tutoring session and receive AI response | ☐ | |
+| Analytics | View learning progress page | ☐ | |
+
+Use `scripts/generate_manual_testing_assets.sh` to create a CSV version of this checklist.

--- a/codex/tests/manual/test_procedures_and_quality_gates.md
+++ b/codex/tests/manual/test_procedures_and_quality_gates.md
@@ -1,0 +1,14 @@
+# Test Procedures and Quality Gates
+
+## Release Workflow
+1. Execute automated CI pipeline.
+2. Perform manual testing checklist.
+3. Conduct UAT with selected families.
+4. Gather bug reports and resolve critical issues.
+5. Product owner signs off release.
+
+## Quality Gates
+- All checklist items passed.
+- No open critical or high severity bugs.
+- UAT approval documented.
+- Documentation and changelog updated.

--- a/codex/tests/manual/uat_scenarios.md
+++ b/codex/tests/manual/uat_scenarios.md
@@ -1,0 +1,19 @@
+# User Acceptance Testing Scenarios
+
+## Scenario 1: Student completes a tutoring session
+- **Precondition:** Student account exists and is logged in.
+- **Steps:**
+  1. Open the tutoring chat.
+  2. Ask a question about mathematics.
+  3. Receive guiding questions from the AI.
+- **Expected Result:** Student receives context-aware prompts leading to the solution.
+
+## Scenario 2: Parent reviews learning progress
+- **Precondition:** Parent account linked to student.
+- **Steps:**
+  1. Open analytics page.
+  2. Select student.
+  3. Review progress chart.
+- **Expected Result:** Parent sees accurate metrics and trends.
+
+Document results for each scenario in the issue tracker.

--- a/codex/tests/manual/usability_testing_plan.md
+++ b/codex/tests/manual/usability_testing_plan.md
@@ -1,0 +1,12 @@
+# Usability Testing Plan
+
+Target groups include parents and students aged 14+.
+
+## Session Structure
+1. Introduction and consent.
+2. Task scenarios (login, tutoring, analytics).
+3. Observation and note taking.
+4. Post-session interview.
+5. Debrief and collect additional comments.
+
+Record findings in a shared spreadsheet generated via the scripts.

--- a/scripts/generate_manual_testing_assets.sh
+++ b/scripts/generate_manual_testing_assets.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+set -e
+OUTPUT_DIR="codex/tests/manual/generated"
+mkdir -p "$OUTPUT_DIR"
+
+cat > "$OUTPUT_DIR/manual_test_checklist.csv" <<'EOC'
+Test Area,Test,Status,Notes
+Login,Login with valid credentials,,
+Registration,Register a new user,,
+Tutoring,Start a tutoring session and receive AI response,,
+Analytics,View learning progress page,,
+EOC
+
+cat > "$OUTPUT_DIR/bug_report_template.csv" <<'EOC'
+Field,Description
+Summary,Short description
+Steps to Reproduce,"Step1; Step2; Step3"
+Expected Result,What should happen
+Actual Result,What happened
+Environment,"App version / Device / OS"
+Additional Info,Optional
+EOC
+
+echo "Templates generated in $OUTPUT_DIR"


### PR DESCRIPTION
## Summary
- add manual testing docs and quality gates
- provide script to generate csv templates for checklist and bug reports
- update roadmap, prompt and changelog for manual testing phase

## Testing
- `scripts/generate_manual_testing_assets.sh`
- `dart format codex/tests/manual codex/daten/roadmap.md codex/daten/prompt.md codex/daten/changelog.md .gitignore scripts/generate_manual_testing_assets.sh` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6895d4151d10832e864ff2e833cd5eac