### PR TITLE
Automate homework model deployment with versioning

### DIFF
--- a/.github/workflows/retrain_model.yml
+++ b/.github/workflows/retrain_model.yml
@@ -1,0 +1,24 @@
+name: Retrain Homework Model
+
+on:
+  schedule:
+    - cron: '0 0 * * 0'
+  workflow_dispatch:
+
+jobs:
+  retrain:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+      - name: Install dependencies
+        run: npm ci --prefix backend
+      - name: Retrain model
+        run: npm run retrain-model --prefix backend
+      - name: Upload model artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: homework-model
+          path: backend/data/homework_model*.bin

--- a/backend/package.json
+++ b/backend/package.json
@@ -4,7 +4,8 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "ts-node --transpile-only tests/security.test.ts && ts-node --transpile-only tests/homework.test.ts"
+    "test": "ts-node --transpile-only tests/security.test.ts && ts-node --transpile-only tests/homework.test.ts",
+    "retrain-model": "ts-node --transpile-only ../scripts/retrain_homework_model.ts"
   },
   "keywords": [],
   "author": "",

--- a/codex/daten/changelog.md
+++ b/codex/daten/changelog.md
@@ -315,3 +315,8 @@
 - Skript `scripts/retrain_homework_model.ts` erstellt, um das Retraining auszuführen und Modell-Datei zu generieren.
 - Tests in `backend/tests/homework.test.ts` erweitert und Feedback-Logbereinigung geprüft.
 - Roadmap und Prompt aktualisiert.
+
+### Phase 2: Automatisierte Modell-Bereitstellung - 2025-08-09
+- GitHub Action konfiguriert wöchentlichen Retrain-Lauf und stellt Modell als Artefakt bereit.
+- NPM-Skript `retrain-model` und Versionstracking für das Modell eingeführt.
+- `setup_homework_detection.sh` legt `model_version.json` automatisch an.

--- a/codex/daten/prompt.md
+++ b/codex/daten/prompt.md
@@ -1,4 +1,4 @@
-# Nächster Schritt: Phase 2 – Automatisierte Modell-Bereitstellung
+# Nächster Schritt: Phase 2 – Modellversions-API
 
 ## Status
 - Phase 0 abgeschlossen ✓
@@ -7,31 +7,33 @@
 - Phase 2: ML-Modell integriert ✓
 - Phase 2: Modell-Evaluierung & Feedback ✓
 - Phase 2: Modell-Retraining automatisiert ✓
+- Phase 2: Modell-Bereitstellung automatisiert ✓
 
 ## Referenzen
 - `/README.md`
 - `/codex/AGENTS.md`
 - `/codex/daten/roadmap.md`
 - `/codex/daten/changelog.md`
+- `backend/package.json`
 - `backend/src/services/homework.service.ts`
 - `backend/tests/homework.test.ts`
 - `scripts/setup_homework_detection.sh`
 - `scripts/retrain_homework_model.ts`
+- `.github/workflows/retrain_model.yml`
 
 ## Nächste Aufgabe
-Automatisiere das Deployment des retrainierten Modells und plane regelmäßige Trainingsläufe.
+Implementiere einen API-Endpunkt, der die aktuelle Modellversion und das letzte Retrain-Datum zurückgibt.
 
 ### Vorbereitungen
-- Zeitplan für regelmäßiges Retraining definieren.
-- Mechanismus zur Modellversionierung entwerfen.
+- Route und Rückgabeformat definieren.
+- Quelle für Retrain-Zeitpunkt festlegen.
 
 ### Implementierungsschritte
-- NPM-Skript oder CI-Job anlegen, der `retrain_homework_model.ts` periodisch ausführt.
-- Modellversions-Tracking in Datenordner integrieren.
-- Dokumentation aktualisieren.
+- Route und Controller für Modellinformationen erstellen.
+- Service um Abfrage von Version und Datum erweitern.
+- Tests und Dokumentation aktualisieren.
 
 ### Validierung
-- `bash -n scripts/setup_homework_detection.sh`
 - `npm test --prefix backend`
 
 ### Selbstgenerierung

--- a/codex/daten/roadmap.md
+++ b/codex/daten/roadmap.md
@@ -315,3 +315,9 @@ Details: Genauigkeit mit Testdaten prüfen und Verbesserungsfeedback sammeln.
 
 [x] Automatisiertes Modell-Retraining mit Feedback-Daten:
 Details: Trainingsskript liest Feedback-Logs ein, aktualisiert Modellgewichte und erzeugt die Modell-Datei.
+
+[x] Automatisierte Modell-Bereitstellung und geplantes Retraining:
+Details: NPM-Skript, GitHub Action und Modellversionierung eingeführt.
+
+[ ] API-Endpunkt für Modellversion und Retrain-Datum:
+Details: Endpoint liefert aktuelle Modellversion und letztes Trainingsdatum.

--- a/scripts/retrain_homework_model.ts
+++ b/scripts/retrain_homework_model.ts
@@ -1,7 +1,10 @@
-import { retrainModel } from '../backend/src/services/homework.service';
+import { retrainModel, getModelVersion } from '../backend/src/services/homework.service';
 
 retrainModel()
-  .then(() => console.log('Homework model retrained'))
+  .then(() => {
+    const version = getModelVersion();
+    console.log(`Homework model retrained to version ${version}`);
+  })
   .catch((err) => {
     console.error(err);
     process.exit(1);

--- a/scripts/setup_homework_detection.sh
+++ b/scripts/setup_homework_detection.sh
@@ -3,6 +3,7 @@ set -e
 
 MODEL_DIR="$(dirname "$0")/../backend/data"
 MODEL_FILE="$MODEL_DIR/homework_model.bin"
+MODEL_VERSION_FILE="$MODEL_DIR/model_version.json"
 
 mkdir -p "$MODEL_DIR"
 
@@ -10,6 +11,10 @@ if [ ! -f "$MODEL_FILE" ]; then
   echo "Downloading homework detection model..."
   curl -L -o "$MODEL_FILE" "https://example.com/models/homework_model.bin"
   echo "Model downloaded to $MODEL_FILE"
+  echo '{ "version": 1 }' > "$MODEL_VERSION_FILE"
 else
   echo "Model already exists at $MODEL_FILE"
+  if [ ! -f "$MODEL_VERSION_FILE" ]; then
+    echo '{ "version": 1 }' > "$MODEL_VERSION_FILE"
+  fi
 fi


### PR DESCRIPTION
## Summary
- introduce model version tracking and deployment helpers
- schedule weekly retraining via GitHub Actions
- document automated deployment and next steps

## Testing
- `bash -n scripts/setup_homework_detection.sh`
- `npm test --prefix backend`


------
https://chatgpt.com/codex/tasks/task_e_6895ec6323a4832eb35b23c9ea31be6b