### PR TITLE
feat: add initial localization support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ flutter_app/*
 flutter_app/mrs_unkwn_app/*
 !flutter_app/mrs_unkwn_app/lib/
 !flutter_app/mrs_unkwn_app/lib/**
+!flutter_app/mrs_unkwn_app/pubspec.yaml
 !flutter_app/mrs_unkwn_app/build.yaml
 !flutter_app/mrs_unkwn_app/test/
 !flutter_app/mrs_unkwn_app/test/**

--- a/backend/src/database/migrations/20250808120000_add_language_to_users.ts
+++ b/backend/src/database/migrations/20250808120000_add_language_to_users.ts
@@ -1,0 +1,13 @@
+import type { Knex } from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.schema.alterTable('users', (table) => {
+    table.string('language').notNullable().defaultTo('en');
+  });
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.alterTable('users', (table) => {
+    table.dropColumn('language');
+  });
+}

--- a/backend/src/repositories/user.repository.ts
+++ b/backend/src/repositories/user.repository.ts
@@ -7,6 +7,7 @@ export interface User {
   first_name: string;
   last_name: string;
   role: 'parent' | 'child';
+  language: string;
   created_at?: Date;
   updated_at?: Date;
 }
@@ -18,7 +19,7 @@ export class UserRepository {
   async create(userData: CreateUserDTO): Promise<User> {
     const [user] = await db<User>('users')
       .insert(userData)
-      .returning(['id', 'email', 'password_hash', 'first_name', 'last_name', 'role', 'created_at', 'updated_at']);
+      .returning(['id', 'email', 'password_hash', 'first_name', 'last_name', 'role', 'language', 'created_at', 'updated_at']);
     return user;
   }
 
@@ -36,7 +37,7 @@ export class UserRepository {
     const [user] = await db<User>('users')
       .where({ id })
       .update(data)
-      .returning(['id', 'email', 'password_hash', 'first_name', 'last_name', 'role', 'created_at', 'updated_at']);
+      .returning(['id', 'email', 'password_hash', 'first_name', 'last_name', 'role', 'language', 'created_at', 'updated_at']);
     return user;
   }
 

--- a/backend/src/routes/auth.routes.ts
+++ b/backend/src/routes/auth.routes.ts
@@ -13,6 +13,7 @@ interface RegisterBody {
   name: string;
   email: string;
   password: string;
+  language?: string;
 }
 
 interface LoginBody {
@@ -24,7 +25,7 @@ router.post(
   '/register',
   validateRequest(userRegistrationSchema),
   async (req: Request<{}, {}, RegisterBody>, res: Response) => {
-    const { name, email, password } = req.body;
+    const { name, email, password, language } = req.body;
     const existing = await userRepository.findByEmail(email);
     if (existing) {
       return res.error('User already exists', 409);
@@ -41,6 +42,7 @@ router.post(
       first_name,
       last_name,
       role: 'parent',
+      language: language ?? 'en',
     });
 
     const tokens = authService.generateTokens(user.id);

--- a/backend/src/routes/user.routes.ts
+++ b/backend/src/routes/user.routes.ts
@@ -1,5 +1,7 @@
 import { Router, Request, Response } from 'express';
+import { body } from 'express-validator';
 import { authenticateToken } from '../middleware/auth.middleware';
+import { validateRequest } from '../middleware/validation.middleware';
 import { userRepository } from '../repositories/user.repository';
 
 const router = Router();
@@ -12,21 +14,33 @@ router.get('/profile', authenticateToken, (req: Request, res: Response) => {
   return res.success({ user });
 });
 
-router.put('/profile', authenticateToken, async (req: Request, res: Response) => {
-  if (!req.user) {
-    return res.error('Unauthorized', 401);
-  }
-  const { first_name, last_name } = req.body as {
-    first_name?: string;
-    last_name?: string;
-  };
-  const updated = await userRepository.update(req.user.id, {
-    first_name: first_name ?? req.user.first_name,
-    last_name: last_name ?? req.user.last_name,
-  });
-  const { password_hash, ...user } = updated;
-  return res.success({ user }, 'Profile updated');
-});
+router.put(
+  '/profile',
+  authenticateToken,
+  [
+    body('first_name').optional().isString(),
+    body('last_name').optional().isString(),
+    body('language').optional().isIn(['en', 'de']),
+  ],
+  validateRequest,
+  async (req: Request, res: Response) => {
+    if (!req.user) {
+      return res.error('Unauthorized', 401);
+    }
+    const { first_name, last_name, language } = req.body as {
+      first_name?: string;
+      last_name?: string;
+      language?: string;
+    };
+    const updated = await userRepository.update(req.user.id, {
+      first_name: first_name ?? req.user.first_name,
+      last_name: last_name ?? req.user.last_name,
+      language: language ?? req.user.language,
+    });
+    const { password_hash, ...user } = updated;
+    return res.success({ user }, 'Profile updated');
+  },
+);
 
 router.delete('/account', authenticateToken, async (req: Request, res: Response) => {
   if (!req.user) {

--- a/backend/src/validation/schemas/userRegistration.schema.ts
+++ b/backend/src/validation/schemas/userRegistration.schema.ts
@@ -17,4 +17,8 @@ export const userRegistrationSchema = [
       minSymbols: 1,
     })
     .withMessage('Password must be at least 8 characters long and include uppercase, lowercase, number and symbol'),
+  body('language')
+    .optional()
+    .isIn(['en', 'de'])
+    .withMessage('Language must be en or de'),
 ];

--- a/codex/daten/changelog.md
+++ b/codex/daten/changelog.md
@@ -329,3 +329,9 @@
 ### Phase 3: Roadmap Planung - 2025-08-09
 - Phase-3-Ziele mit Meilensteinen (Multi-Language, Schul-Integrationen, Analytics, B2B) zur `roadmap.md` hinzugefügt
 - `prompt.md` auf nächsten Schritt aktualisiert
+
+### Phase 3: Multi-Language Support Infrastruktur - 2025-08-09
+- Flutter-App mit Lokalisierungs-Framework und ARB-Dateien für Deutsch/Englisch erweitert
+- Backend um Spracheinstellungen inkl. Migration und API-Updates ergänzt
+- Skript `scripts/generate_translations.sh` zur automatischen Generierung von Übersetzungsdateien erstellt
+- Roadmap und Prompt aktualisiert

--- a/codex/daten/prompt.md
+++ b/codex/daten/prompt.md
@@ -1,10 +1,10 @@
-# Nächster Schritt: Phase 3 – Multi-Language Support implementieren
+# Nächster Schritt: Phase 3 – Schul-Integrationen implementieren
 
 ## Status
 - Phase 0 abgeschlossen ✓
 - Phase 1 abgeschlossen ✓
 - Phase 2 abgeschlossen ✓
-- Phase 3 Roadmap erstellt ✓
+- Phase 3 Milestone 1 abgeschlossen ✓
 
 ## Referenzen
 - `/README.md`
@@ -13,15 +13,14 @@
 - `/codex/daten/changelog.md`
 
 ## Nächste Aufgabe
-Implementiere die grundlegende Infrastruktur für Multi-Language Support.
+Implementiere grundlegende Schnittstellen zu Schulverwaltungssystemen.
 
 ### Vorbereitungen
-- Bestehende App- und Backend-Struktur analysieren.
+- Bestehende Backend-Architektur analysieren.
 
 ### Implementierungsschritte
-- Lokalisierungsframework im Flutter-Projekt einrichten.
-- Backend um Spracheinstellungen erweitern.
-- Skript `scripts/generate_translations.sh` erstellen, das Übersetzungsdateien automatisch generiert.
+- Schnittstellen zu gängigen Schulverwaltungssystemen (z.B. LDAP, SSO) hinzufügen.
+- Skript `scripts/setup_school_integrations.sh` erstellen, das benötigte Konnektoren automatisch einrichtet.
 
 ### Validierung
 - `python -m py_compile` auf geänderten Python-Dateien ausführen.
@@ -31,4 +30,3 @@ Implementiere die grundlegende Infrastruktur für Multi-Language Support.
 - Nach Abschluss dieses Schrittes automatisch den nächsten Prompt in `/codex/daten/prompt.md` schreiben.
 
 *Hinweis: Codex kann keine Binärdateien mergen. Benötigte Dateien werden durch Skripte generiert. Halte den Codeumfang dieses Sprints unter 500 Zeilen.*
-

--- a/codex/daten/roadmap.md
+++ b/codex/daten/roadmap.md
@@ -328,8 +328,8 @@ Details: Endpoint liefert aktuelle Modellversion und letztes Trainingsdatum.
 
 ### Milestone 1: Multi-Language Support
 
-- [ ] UI- und Backend-Lokalisierung für Deutsch und Englisch
-- [ ] Skript `scripts/generate_translations.sh` erzeugt Übersetzungsdateien automatisch
+- [x] UI- und Backend-Lokalisierung für Deutsch und Englisch
+- [x] Skript `scripts/generate_translations.sh` erzeugt Übersetzungsdateien automatisch
 
 ### Milestone 2: Schul-Integrationen
 

--- a/flutter_app/mrs_unkwn_app/lib/app.dart
+++ b/flutter_app/mrs_unkwn_app/lib/app.dart
@@ -1,4 +1,6 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'l10n/app_localizations.dart';
 
 class MrsUnkwnApp extends StatelessWidget {
   const MrsUnkwnApp({super.key});
@@ -8,6 +10,16 @@ class MrsUnkwnApp extends StatelessWidget {
     return MaterialApp(
       title: 'Mrs-Unkwn',
       theme: ThemeData(primarySwatch: Colors.blue),
+      localizationsDelegates: const [
+        AppLocalizations.delegate,
+        GlobalMaterialLocalizations.delegate,
+        GlobalWidgetsLocalizations.delegate,
+        GlobalCupertinoLocalizations.delegate,
+      ],
+      supportedLocales: const [
+        Locale('en'),
+        Locale('de'),
+      ],
       home: const Placeholder(),
     );
   }

--- a/flutter_app/mrs_unkwn_app/lib/l10n/app_de.arb
+++ b/flutter_app/mrs_unkwn_app/lib/l10n/app_de.arb
@@ -1,0 +1,4 @@
+{
+  "appTitle": "Mrs-Unkwn",
+  "hello": "Hallo"
+}

--- a/flutter_app/mrs_unkwn_app/lib/l10n/app_en.arb
+++ b/flutter_app/mrs_unkwn_app/lib/l10n/app_en.arb
@@ -1,0 +1,4 @@
+{
+  "appTitle": "Mrs-Unkwn",
+  "hello": "Hello"
+}

--- a/flutter_app/mrs_unkwn_app/pubspec.yaml
+++ b/flutter_app/mrs_unkwn_app/pubspec.yaml
@@ -1,0 +1,19 @@
+name: mrs_unkwn_app
+description: Mrs-Unkwn Flutter app
+environment:
+  sdk: ">=3.0.0 <4.0.0"
+
+dependencies:
+  flutter:
+    sdk: flutter
+  flutter_localizations:
+    sdk: flutter
+  intl: ^0.18.0
+
+flutter:
+  uses-material-design: true
+  generate: true
+  l10n:
+    arb-dir: lib/l10n
+    template-arb-file: app_en.arb
+    output-localization-file: app_localizations.dart

--- a/scripts/generate_translations.sh
+++ b/scripts/generate_translations.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -e
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+APP_DIR="$SCRIPT_DIR/../flutter_app/mrs_unkwn_app"
+cd "$APP_DIR"
+flutter gen-l10n --arb-dir=lib/l10n --template-arb-file=app_en.arb --output-localization-file=app_localizations.dart
+


### PR DESCRIPTION
## Summary
- add user language support to backend and migration
- integrate localization framework into Flutter app with English and German ARB files
- provide script to generate localization artifacts and update docs

## Testing
- `npm test`
- `flutter test` *(fails: process interrupted while building tool)*
- `bash scripts/generate_translations.sh` *(fails: process interrupted while building tool)*

------
https://chatgpt.com/codex/tasks/task_e_6895fc50a674832e99f5823ac7ddbc8a