### PR TITLE
Add analytics dashboard and demo data script

### DIFF
--- a/codex/daten/changelog.md
+++ b/codex/daten/changelog.md
@@ -340,3 +340,8 @@
 - LDAP- und SSO-Schnittstellen im Backend hinzugefügt
 - Skript `scripts/setup_school_integrations.sh` erzeugt benötigte Konfigurationsdatei und installiert Abhängigkeiten
 - Roadmap und Prompt aktualisiert
+
+### Phase 3: Advanced Analytics Dashboard - 2025-08-09
+- `AnalyticsDashboardPage` visualisiert aggregierte Lernmetriken und ermöglicht CSV-Export
+- Skript `scripts/generate_analytics_data.sh` generiert Demo-Datensätze
+- Roadmap und Prompt aktualisiert

--- a/codex/daten/prompt.md
+++ b/codex/daten/prompt.md
@@ -1,4 +1,4 @@
-# Nächster Schritt: Phase 3 – Advanced Analytics Dashboard implementieren
+# Nächster Schritt: Phase 3 – B2B Features implementieren
 
 ## Status
 - Phase 0 abgeschlossen ✓
@@ -6,6 +6,7 @@
 - Phase 2 abgeschlossen ✓
 - Phase 3 Milestone 1 abgeschlossen ✓
 - Phase 3 Milestone 2 abgeschlossen ✓
+- Phase 3 Milestone 3 abgeschlossen ✓
 
 ## Referenzen
 - `/README.md`
@@ -14,14 +15,14 @@
 - `/codex/daten/changelog.md`
 
 ## Nächste Aufgabe
-Implementiere ein Dashboard mit aggregierten Lernmetriken und Exportfunktion.
+Organisations-Accounts und Rollenverwaltung einführen.
 
 ### Vorbereitungen
-- Bestehende Flutter-App und Backend-APIs analysieren.
+- Backend- und Flutter-Strukturen für Nutzerverwaltung prüfen.
 
 ### Implementierungsschritte
-- Dashboard mit aggregierten Lernmetriken und Exportfunktion erstellen.
-- Skript `scripts/generate_analytics_data.sh` erstellen, das Demo-Datensätze generiert.
+- Organisations-Accounts und Rollenverwaltung einführen.
+- Skript `scripts/create_sample_organizations.sh` erstellen, das Beispiel-Organisationen anlegt.
 
 ### Validierung
 - `python -m py_compile` auf geänderten Python-Dateien ausführen.
@@ -31,4 +32,3 @@ Implementiere ein Dashboard mit aggregierten Lernmetriken und Exportfunktion.
 - Nach Abschluss dieses Schrittes automatisch den nächsten Prompt in `/codex/daten/prompt.md` schreiben.
 
 *Hinweis: Codex kann keine Binärdateien mergen. Benötigte Dateien werden durch Skripte generiert. Halte den Codeumfang dieses Sprints unter 500 Zeilen.*
-

--- a/codex/daten/roadmap.md
+++ b/codex/daten/roadmap.md
@@ -338,8 +338,8 @@ Details: Endpoint liefert aktuelle Modellversion und letztes Trainingsdatum.
 
 ### Milestone 3: Advanced Analytics Dashboard
 
-- [ ] Dashboard mit aggregierten Lernmetriken und Exportfunktion
-- [ ] Skript `scripts/generate_analytics_data.sh` erstellt Demo-Datensätze
+ - [x] Dashboard mit aggregierten Lernmetriken und Exportfunktion
+ - [x] Skript `scripts/generate_analytics_data.sh` erstellt Demo-Datensätze
 
 ### Milestone 4: B2B Features
 

--- a/flutter_app/mrs_unkwn_app/lib/core/di/service_locator.dart
+++ b/flutter_app/mrs_unkwn_app/lib/core/di/service_locator.dart
@@ -5,6 +5,7 @@ import '../../features/tutoring/data/services/ai_response_service.dart';
 import '../../features/tutoring/data/services/subject_classification_service.dart';
 import '../../features/tutoring/data/services/content_moderation_service.dart';
 import '../../features/analytics/data/services/learning_analytics_service.dart';
+import '../../features/analytics/data/services/analytics_export_service.dart';
 import '../storage/secure_storage_service.dart';
 import '../../features/tutoring/data/services/chat_history_service.dart';
 
@@ -41,6 +42,9 @@ void _registerFeatures() {
   );
   sl.registerLazySingleton<LearningAnalyticsService>(
     () => LearningAnalyticsService(),
+  );
+  sl.registerLazySingleton<AnalyticsExportService>(
+    () => AnalyticsExportService(),
   );
   sl.registerLazySingleton<ChatHistoryService>(
     () => ChatHistoryService(sl()),

--- a/flutter_app/mrs_unkwn_app/lib/core/routing/app_router.dart
+++ b/flutter_app/mrs_unkwn_app/lib/core/routing/app_router.dart
@@ -4,6 +4,7 @@ import 'package:go_router/go_router.dart';
 import '../storage/secure_storage_service.dart';
 import 'route_constants.dart';
 import '../../features/monitoring/presentation/pages/monitoring_dashboard_page.dart';
+import '../../features/analytics/presentation/pages/analytics_dashboard_page.dart';
 
 /// Central application router using [GoRouter].
 class AppRouter {
@@ -33,6 +34,11 @@ class AppRouter {
       GoRoute(
         path: RouteConstants.monitoring,
         builder: (context, state) => const MonitoringDashboardPage(),
+        redirect: _authGuard,
+      ),
+      GoRoute(
+        path: RouteConstants.analytics,
+        builder: (context, state) => const AnalyticsDashboardPage(),
         redirect: _authGuard,
       ),
     ],

--- a/flutter_app/mrs_unkwn_app/lib/core/routing/route_constants.dart
+++ b/flutter_app/mrs_unkwn_app/lib/core/routing/route_constants.dart
@@ -4,4 +4,5 @@ class RouteConstants {
   static const String home = '/home';
   static const String familySetup = '/family-setup';
   static const String monitoring = '/monitoring';
+  static const String analytics = '/analytics';
 }

--- a/flutter_app/mrs_unkwn_app/lib/features/analytics/data/services/analytics_export_service.dart
+++ b/flutter_app/mrs_unkwn_app/lib/features/analytics/data/services/analytics_export_service.dart
@@ -1,0 +1,15 @@
+import '../models/learning_report.dart';
+
+/// Converts analytics reports into exportable formats.
+class AnalyticsExportService {
+  /// Generates a simple CSV representation of a [LearningReport].
+  String generateCsv(LearningReport report) {
+    final buffer = StringBuffer();
+    buffer.writeln('Subject,Minutes');
+    report.metrics.timePerSubject.forEach((subject, duration) {
+      buffer.writeln('$subject,${duration.inMinutes}');
+    });
+    buffer.writeln('LearningVelocity,${report.metrics.learningVelocity}');
+    return buffer.toString();
+  }
+}

--- a/flutter_app/mrs_unkwn_app/lib/features/analytics/presentation/pages/analytics_dashboard_page.dart
+++ b/flutter_app/mrs_unkwn_app/lib/features/analytics/presentation/pages/analytics_dashboard_page.dart
@@ -1,0 +1,64 @@
+import 'package:flutter/material.dart';
+
+import '../../../../core/di/service_locator.dart';
+import '../../data/services/learning_analytics_service.dart';
+import '../../data/services/analytics_export_service.dart';
+
+/// Displays aggregated learning metrics with an export option.
+class AnalyticsDashboardPage extends StatelessWidget {
+  const AnalyticsDashboardPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final analytics = sl<LearningAnalyticsService>();
+    final exportService = sl<AnalyticsExportService>();
+    final report = analytics.generateReport();
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Analytics Dashboard'),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.download),
+            onPressed: () {
+              final csv = exportService.generateCsv(report);
+              showDialog(
+                context: context,
+                builder: (context) => AlertDialog(
+                  title: const Text('Exported CSV'),
+                  content: SingleChildScrollView(child: Text(csv)),
+                ),
+              );
+            },
+          )
+        ],
+      ),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              'Learning Velocity: '
+              '${report.metrics.learningVelocity.toStringAsFixed(2)} questions/min',
+            ),
+            const SizedBox(height: 16),
+            const Text('Time per Subject:'),
+            Expanded(
+              child: ListView(
+                children: report.metrics.timePerSubject.entries
+                    .map(
+                      (e) => ListTile(
+                        title: Text(e.key),
+                        trailing: Text('${e.value.inMinutes} min'),
+                      ),
+                    )
+                    .toList(),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/scripts/generate_analytics_data.sh
+++ b/scripts/generate_analytics_data.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+# Generates demo analytics data for the Flutter app.
+set -e
+
+OUTPUT="flutter_app/mrs_unkwn_app/assets/analytics/demo_data.json"
+mkdir -p "$(dirname "$OUTPUT")"
+cat > "$OUTPUT" <<'JSON'
+{
+  "sessions": [
+    {"id": "s1", "subject": "math", "minutes": 30, "questions": 15},
+    {"id": "s2", "subject": "english", "minutes": 20, "questions": 10}
+  ]
+}
+JSON
+
+echo "Demo analytics data written to $OUTPUT"


### PR DESCRIPTION
## Summary
- add `AnalyticsDashboardPage` with aggregated metrics and CSV export
- register analytics route and export service
- provide `generate_analytics_data.sh` script for demo datasets and update docs

## Testing
- `flutter test` *(fails: command not found)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689604475aec832eb66f3e0376a11a67