### PR TITLE
feat: add organization accounts and role management

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "ts-node --transpile-only tests/security.test.ts && ts-node --transpile-only tests/homework.test.ts",
+    "test": "ts-node --transpile-only tests/security.test.ts && ts-node --transpile-only tests/homework.test.ts && ts-node --transpile-only tests/organization.test.ts",
     "retrain-model": "ts-node --transpile-only ../scripts/retrain_homework_model.ts"
   },
   "keywords": [],

--- a/backend/src/database/migrations/20250809130000_create_organizations_table.ts
+++ b/backend/src/database/migrations/20250809130000_create_organizations_table.ts
@@ -1,0 +1,25 @@
+import { Knex } from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.schema.createTable('organizations', (table) => {
+    table.uuid('id').primary().defaultTo(knex.raw('uuid_generate_v4()'));
+    table.string('name').notNullable();
+    table.timestamps(true, true);
+  });
+
+  await knex.schema.createTable('user_organizations', (table) => {
+    table.uuid('user_id').references('id').inTable('users').onDelete('CASCADE');
+    table
+      .uuid('organization_id')
+      .references('id')
+      .inTable('organizations')
+      .onDelete('CASCADE');
+    table.enu('role', ['admin', 'member']).notNullable().defaultTo('member');
+    table.primary(['user_id', 'organization_id']);
+  });
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.dropTableIfExists('user_organizations');
+  await knex.schema.dropTableIfExists('organizations');
+}

--- a/backend/src/repositories/organization.repository.ts
+++ b/backend/src/repositories/organization.repository.ts
@@ -1,0 +1,40 @@
+import { db } from '../database/connection';
+
+export interface Organization {
+  id: string;
+  name: string;
+  created_at?: Date;
+  updated_at?: Date;
+}
+
+export interface UserOrganization {
+  user_id: string;
+  organization_id: string;
+  role: 'admin' | 'member';
+}
+
+export class OrganizationRepository {
+  async create(name: string): Promise<Organization> {
+    const [org] = await db<Organization>('organizations')
+      .insert({ name })
+      .returning(['id', 'name', 'created_at', 'updated_at']);
+    return org;
+  }
+
+  async addUser(organization_id: string, user_id: string, role: 'admin' | 'member'): Promise<void> {
+    await db<UserOrganization>('user_organizations').insert({
+      organization_id,
+      user_id,
+      role,
+    });
+  }
+
+  async findByUser(user_id: string): Promise<Array<Organization & { role: string }>> {
+    return db<Organization>('organizations as o')
+      .select('o.id', 'o.name', 'o.created_at', 'o.updated_at', 'uo.role')
+      .join('user_organizations as uo', 'o.id', 'uo.organization_id')
+      .where('uo.user_id', user_id);
+  }
+}
+
+export const organizationRepository = new OrganizationRepository();

--- a/backend/src/routes/index.ts
+++ b/backend/src/routes/index.ts
@@ -3,6 +3,7 @@ import authRoutes from './auth.routes';
 import userRoutes from './user.routes';
 import homeworkRoutes from './homework.routes';
 import schoolRoutes from './school.routes';
+import organizationRoutes from './organization.routes';
 
 const router = Router();
 
@@ -10,5 +11,6 @@ router.use('/auth', authRoutes);
 router.use('/user', userRoutes);
 router.use('/homework', homeworkRoutes);
 router.use('/school', schoolRoutes);
+router.use('/organizations', organizationRoutes);
 
 export default router;

--- a/backend/src/routes/organization.routes.ts
+++ b/backend/src/routes/organization.routes.ts
@@ -1,0 +1,43 @@
+import { Router, Request, Response } from 'express';
+import { body, param } from 'express-validator';
+import { authenticateToken } from '../middleware/auth.middleware';
+import { validateRequest } from '../middleware/validation.middleware';
+import { organizationService } from '../services/organization.service';
+
+const router = Router();
+
+router.post(
+  '/',
+  authenticateToken,
+  [body('name').isString()],
+  validateRequest,
+  async (req: Request, res: Response) => {
+    const { name } = req.body as { name: string };
+    const org = await organizationService.createOrganization(name, req.user!.id);
+    return res.success({ organization: org }, 'Organization created');
+  },
+);
+
+router.post(
+  '/:id/users',
+  authenticateToken,
+  [
+    param('id').isUUID(),
+    body('userId').isUUID(),
+    body('role').isIn(['admin', 'member']),
+  ],
+  validateRequest,
+  async (req: Request, res: Response) => {
+    const { id } = req.params as { id: string };
+    const { userId, role } = req.body as { userId: string; role: 'admin' | 'member' };
+    await organizationService.addUser(id, userId, role);
+    return res.success(null, 'User added to organization');
+  },
+);
+
+router.get('/', authenticateToken, async (req: Request, res: Response) => {
+  const orgs = await organizationService.getUserOrganizations(req.user!.id);
+  return res.success({ organizations: orgs });
+});
+
+export default router;

--- a/backend/src/services/organization.service.ts
+++ b/backend/src/services/organization.service.ts
@@ -1,0 +1,19 @@
+import { organizationRepository } from '../repositories/organization.repository';
+
+class OrganizationService {
+  async createOrganization(name: string, ownerId: string) {
+    const org = await organizationRepository.create(name);
+    await organizationRepository.addUser(org.id, ownerId, 'admin');
+    return org;
+  }
+
+  async addUser(organizationId: string, userId: string, role: 'admin' | 'member') {
+    await organizationRepository.addUser(organizationId, userId, role);
+  }
+
+  async getUserOrganizations(userId: string) {
+    return organizationRepository.findByUser(userId);
+  }
+}
+
+export const organizationService = new OrganizationService();

--- a/backend/tests/organization.test.ts
+++ b/backend/tests/organization.test.ts
@@ -1,0 +1,21 @@
+import assert from 'node:assert';
+import { AddressInfo } from 'node:net';
+
+process.env.DATABASE_URL = 'postgres://user:pass@localhost:5432/test';
+process.env.JWT_SECRET = 'test-secret';
+process.env.JWT_REFRESH_SECRET = 'test-refresh';
+process.env.EMAIL_SERVICE_KEY = 'test-email';
+process.env.NODE_ENV = 'test';
+
+import app from '../src/index';
+
+const server = app.listen(0, async () => {
+  const port = (server.address() as AddressInfo).port;
+  const baseUrl = `http://localhost:${port}`;
+
+  const res = await fetch(`${baseUrl}/api/organizations`);
+  assert.strictEqual(res.status, 401);
+
+  console.log('Organization route security test passed');
+  server.close();
+});

--- a/codex/daten/changelog.md
+++ b/codex/daten/changelog.md
@@ -345,3 +345,9 @@
 - `AnalyticsDashboardPage` visualisiert aggregierte Lernmetriken und ermöglicht CSV-Export
 - Skript `scripts/generate_analytics_data.sh` generiert Demo-Datensätze
 - Roadmap und Prompt aktualisiert
+
+### Phase 3: B2B Features - 2025-08-09
+- Organisations-Accounts und Rollenverwaltung implementiert
+- Skript `scripts/create_sample_organizations.sh` erstellt Beispiel-Organisationen
+- Backend-Migration, Repositories, Services und Routen für Organisationen hinzugefügt
+- Flutter-Service und Modell zur Organisationsverwaltung erstellt

--- a/codex/daten/prompt.md
+++ b/codex/daten/prompt.md
@@ -1,4 +1,4 @@
-# Nächster Schritt: Phase 3 – B2B Features implementieren
+# Nächster Schritt: Phase 4 – API für Drittanbieter vorbereiten
 
 ## Status
 - Phase 0 abgeschlossen ✓
@@ -7,6 +7,7 @@
 - Phase 3 Milestone 1 abgeschlossen ✓
 - Phase 3 Milestone 2 abgeschlossen ✓
 - Phase 3 Milestone 3 abgeschlossen ✓
+- Phase 3 Milestone 4 abgeschlossen ✓
 
 ## Referenzen
 - `/README.md`
@@ -15,14 +16,14 @@
 - `/codex/daten/changelog.md`
 
 ## Nächste Aufgabe
-Organisations-Accounts und Rollenverwaltung einführen.
+API für Drittanbieter vorbereiten.
 
 ### Vorbereitungen
-- Backend- und Flutter-Strukturen für Nutzerverwaltung prüfen.
+- Analyse bestehender API-Struktur im Backend.
 
 ### Implementierungsschritte
-- Organisations-Accounts und Rollenverwaltung einführen.
-- Skript `scripts/create_sample_organizations.sh` erstellen, das Beispiel-Organisationen anlegt.
+- Öffentliche API-Endpunkte für Drittanbieter definieren und dokumentieren.
+- Authentifizierungsmechanismus mit API-Schlüsseln einführen.
 
 ### Validierung
 - `python -m py_compile` auf geänderten Python-Dateien ausführen.

--- a/codex/daten/roadmap.md
+++ b/codex/daten/roadmap.md
@@ -343,5 +343,5 @@ Details: Endpoint liefert aktuelle Modellversion und letztes Trainingsdatum.
 
 ### Milestone 4: B2B Features
 
-- [ ] Organisations-Accounts und Rollenverwaltung einführen
-- [ ] Skript `scripts/create_sample_organizations.sh` legt Beispiel-Organisationen an
+- [x] Organisations-Accounts und Rollenverwaltung einführen
+- [x] Skript `scripts/create_sample_organizations.sh` legt Beispiel-Organisationen an

--- a/flutter_app/mrs_unkwn_app/lib/core/di/service_locator.dart
+++ b/flutter_app/mrs_unkwn_app/lib/core/di/service_locator.dart
@@ -1,6 +1,7 @@
 import 'package:get_it/get_it.dart';
 import '../services/openai_service.dart';
 import '../services/monitoring_service.dart';
+import '../network/dio_client.dart';
 import '../../features/tutoring/data/services/ai_response_service.dart';
 import '../../features/tutoring/data/services/subject_classification_service.dart';
 import '../../features/tutoring/data/services/content_moderation_service.dart';
@@ -8,6 +9,7 @@ import '../../features/analytics/data/services/learning_analytics_service.dart';
 import '../../features/analytics/data/services/analytics_export_service.dart';
 import '../storage/secure_storage_service.dart';
 import '../../features/tutoring/data/services/chat_history_service.dart';
+import '../../features/organization/data/organization_service.dart';
 
 final sl = GetIt.instance;
 
@@ -48,6 +50,9 @@ void _registerFeatures() {
   );
   sl.registerLazySingleton<ChatHistoryService>(
     () => ChatHistoryService(sl()),
+  );
+  sl.registerLazySingleton<OrganizationService>(
+    () => OrganizationService(DioClient()),
   );
 }
 

--- a/flutter_app/mrs_unkwn_app/lib/features/organization/data/organization_service.dart
+++ b/flutter_app/mrs_unkwn_app/lib/features/organization/data/organization_service.dart
@@ -1,0 +1,24 @@
+import '../../../core/network/dio_client.dart';
+import '../models/organization.dart';
+
+class OrganizationService {
+  final DioClient _client;
+  OrganizationService(this._client);
+
+  Future<List<Organization>> fetchOrganizations() async {
+    final res = await _client.get('/organizations');
+    final list = (res.data['organizations'] as List)
+        .map((e) => Organization.fromJson(e as Map<String, dynamic>))
+        .toList();
+    return list;
+  }
+
+  Future<Organization> createOrganization(String name) async {
+    final res = await _client.post('/organizations', data: {'name': name});
+    return Organization.fromJson(res.data['organization']);
+  }
+
+  Future<void> addUser(String orgId, String userId, String role) async {
+    await _client.post('/organizations/$orgId/users', data: {'userId': userId, 'role': role});
+  }
+}

--- a/flutter_app/mrs_unkwn_app/lib/features/organization/models/organization.dart
+++ b/flutter_app/mrs_unkwn_app/lib/features/organization/models/organization.dart
@@ -1,0 +1,23 @@
+class Organization {
+  final String id;
+  final String name;
+  final String role;
+
+  Organization({required this.id, required this.name, required this.role});
+
+  factory Organization.fromJson(Map<String, dynamic> json) {
+    return Organization(
+      id: json['id'] as String,
+      name: json['name'] as String,
+      role: json['role'] as String,
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'id': id,
+      'name': name,
+      'role': role,
+    };
+  }
+}

--- a/scripts/create_sample_organizations.sh
+++ b/scripts/create_sample_organizations.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -e
+
+if [ -z "$DATABASE_URL" ]; then
+  echo "DATABASE_URL is not set"
+  exit 1
+fi
+
+psql "$DATABASE_URL" <<'SQL'
+INSERT INTO organizations (name) VALUES
+  ('Sample Org A'),
+  ('Sample Org B')
+ON CONFLICT DO NOTHING;
+SQL
+
+echo "Sample organizations created"


### PR DESCRIPTION
## Summary
- add migrations, repository and service for organizations with role mapping
- expose organization REST endpoints and sample data script
- integrate Flutter-side organization service and model

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `npm test`
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68960c3f16f8832ea4c9bc784ef9b337