### PR TITLE
feat: add API key service and external routes

### DIFF
--- a/backend/src/database/migrations/20250810000000_create_api_keys_table.ts
+++ b/backend/src/database/migrations/20250810000000_create_api_keys_table.ts
@@ -1,0 +1,15 @@
+import type { Knex } from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.schema.createTable('api_keys', (table) => {
+    table.uuid('id').primary();
+    table.string('key').notNullable().unique();
+    table.string('partner_name').notNullable();
+    table.boolean('revoked').defaultTo(false);
+    table.timestamps(true, true);
+  });
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.dropTable('api_keys');
+}

--- a/backend/src/middleware/apiKey.middleware.ts
+++ b/backend/src/middleware/apiKey.middleware.ts
@@ -1,0 +1,20 @@
+import { Request, Response, NextFunction } from 'express';
+import { apiKeyService } from '../services/apiKey.service';
+
+export const verifyApiKey = async (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): Promise<void> => {
+  const key = req.headers['x-api-key'];
+  if (typeof key !== 'string') {
+    res.error('API key required', 401);
+    return;
+  }
+  const valid = await apiKeyService.validateKey(key);
+  if (!valid) {
+    res.error('Invalid API key', 403);
+    return;
+  }
+  next();
+};

--- a/backend/src/repositories/apiKey.repository.ts
+++ b/backend/src/repositories/apiKey.repository.ts
@@ -1,0 +1,32 @@
+import { db } from '../database/connection';
+
+export interface ApiKey {
+  id: string;
+  key: string;
+  partner_name: string;
+  revoked: boolean;
+  created_at?: Date;
+  updated_at?: Date;
+}
+
+export type CreateApiKeyDTO = Omit<ApiKey, 'id' | 'revoked' | 'created_at' | 'updated_at'>;
+
+export class ApiKeyRepository {
+  async create(data: CreateApiKeyDTO): Promise<ApiKey> {
+    const [apiKey] = await db<ApiKey>('api_keys')
+      .insert({ ...data, revoked: false })
+      .returning(['id', 'key', 'partner_name', 'revoked', 'created_at', 'updated_at']);
+    return apiKey;
+  }
+
+  async findByKey(key: string): Promise<ApiKey | null> {
+    const apiKey = await db<ApiKey>('api_keys').where({ key }).first();
+    return apiKey || null;
+  }
+
+  async revoke(key: string): Promise<void> {
+    await db<ApiKey>('api_keys').where({ key }).update({ revoked: true });
+  }
+}
+
+export const apiKeyRepository = new ApiKeyRepository();

--- a/backend/src/routes/external.routes.ts
+++ b/backend/src/routes/external.routes.ts
@@ -1,0 +1,20 @@
+import { Router } from 'express';
+import { verifyApiKey } from '../middleware/apiKey.middleware';
+import { userRepository } from '../repositories/user.repository';
+
+const router = Router();
+
+router.get('/health', verifyApiKey, (_req, res) => {
+  res.success({ status: 'ok' });
+});
+
+router.get('/users/:id', verifyApiKey, async (req, res) => {
+  const user = await userRepository.findById(req.params.id);
+  if (!user) {
+    res.error('User not found', 404);
+    return;
+  }
+  res.success(user);
+});
+
+export default router;

--- a/backend/src/routes/index.ts
+++ b/backend/src/routes/index.ts
@@ -4,6 +4,7 @@ import userRoutes from './user.routes';
 import homeworkRoutes from './homework.routes';
 import schoolRoutes from './school.routes';
 import organizationRoutes from './organization.routes';
+import externalRoutes from './external.routes';
 
 const router = Router();
 
@@ -12,5 +13,6 @@ router.use('/user', userRoutes);
 router.use('/homework', homeworkRoutes);
 router.use('/school', schoolRoutes);
 router.use('/organizations', organizationRoutes);
+router.use('/external', externalRoutes);
 
 export default router;

--- a/backend/src/services/apiKey.service.ts
+++ b/backend/src/services/apiKey.service.ts
@@ -1,0 +1,21 @@
+import crypto from 'crypto';
+import { apiKeyRepository } from '../repositories/apiKey.repository';
+
+class ApiKeyService {
+  async generateKey(partnerName: string): Promise<string> {
+    const key = crypto.randomBytes(32).toString('hex');
+    await apiKeyRepository.create({ key, partner_name: partnerName });
+    return key;
+  }
+
+  async validateKey(key: string): Promise<boolean> {
+    const record = await apiKeyRepository.findByKey(key);
+    return !!record && !record.revoked;
+  }
+
+  async revokeKey(key: string): Promise<void> {
+    await apiKeyRepository.revoke(key);
+  }
+}
+
+export const apiKeyService = new ApiKeyService();

--- a/backend/third_party_api.md
+++ b/backend/third_party_api.md
@@ -1,0 +1,10 @@
+# Drittanbieter API
+
+## Authentifizierung
+Alle Anfragen müssen den Header `x-api-key` mit einem gültigen Schlüssel enthalten.
+
+## Endpunkte
+- `GET /api/external/health` – Prüft den API-Status.
+- `GET /api/external/users/:id` – Liefert Basisinformationen zu einem Benutzer.
+
+Weitere Endpunkte folgen.

--- a/codex/daten/changelog.md
+++ b/codex/daten/changelog.md
@@ -351,3 +351,9 @@
 - Skript `scripts/create_sample_organizations.sh` erstellt Beispiel-Organisationen
 - Backend-Migration, Repositories, Services und Routen für Organisationen hinzugefügt
 - Flutter-Service und Modell zur Organisationsverwaltung erstellt
+
+### Phase 4: Drittanbieter API vorbereitet - 2025-08-10
+- Tabelle `api_keys` mit Migration hinzugefügt
+- `ApiKeyRepository`, `ApiKeyService`, Middleware und externe Routen implementiert
+- Dokumentation `backend/third_party_api.md` erstellt
+- Roadmap und Prompt aktualisiert

--- a/codex/daten/prompt.md
+++ b/codex/daten/prompt.md
@@ -1,4 +1,4 @@
-# Nächster Schritt: Phase 4 – API für Drittanbieter vorbereiten
+# Nächster Schritt: Phase 4 – Developer-Portal & Rate-Limiting
 
 ## Status
 - Phase 0 abgeschlossen ✓
@@ -8,6 +8,7 @@
 - Phase 3 Milestone 2 abgeschlossen ✓
 - Phase 3 Milestone 3 abgeschlossen ✓
 - Phase 3 Milestone 4 abgeschlossen ✓
+- Phase 4 Milestone 1 abgeschlossen ✓
 
 ## Referenzen
 - `/README.md`
@@ -16,14 +17,15 @@
 - `/codex/daten/changelog.md`
 
 ## Nächste Aufgabe
-API für Drittanbieter vorbereiten.
+Developer-Portal und Rate-Limiting implementieren.
 
 ### Vorbereitungen
-- Analyse bestehender API-Struktur im Backend.
+- Bestehenden API-Key-Service und externe Routen analysieren.
+- Recherche zu `express-rate-limit`.
 
 ### Implementierungsschritte
-- Öffentliche API-Endpunkte für Drittanbieter definieren und dokumentieren.
-- Authentifizierungsmechanismus mit API-Schlüsseln einführen.
+- Developer-Portal zur Verwaltung von API-Schlüsseln aufsetzen.
+- Rate-Limiting für externe Endpunkte hinzufügen.
 
 ### Validierung
 - `python -m py_compile` auf geänderten Python-Dateien ausführen.

--- a/codex/daten/roadmap.md
+++ b/codex/daten/roadmap.md
@@ -345,3 +345,12 @@ Details: Endpoint liefert aktuelle Modellversion und letztes Trainingsdatum.
 
 - [x] Organisations-Accounts und Rollenverwaltung einführen
 - [x] Skript `scripts/create_sample_organizations.sh` legt Beispiel-Organisationen an
+
+# Mrs-Unkwn Entwicklungsroadmap - Phase 4 (Monate 19-24)
+
+## Phase 4: Platform Evolution
+
+### Milestone 1: Drittanbieter-API
+- [x] Öffentliche API-Endpunkte und Authentifizierung mit API-Schlüsseln
+- [ ] Developer-Portal und Rate-Limiting implementieren
+


### PR DESCRIPTION
## Summary
- add API key migration, repository, service, middleware, and routes for third-party access
- document external API usage and update roadmap/prompt

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `flutter test` *(fails: command not found)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6896103ac2dc832ea376f99008e93f4c