### PR TITLE
feat: add developer portal and rate limiting

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "ts-node --transpile-only tests/security.test.ts && ts-node --transpile-only tests/homework.test.ts && ts-node --transpile-only tests/organization.test.ts",
+    "test": "ts-node --transpile-only tests/security.test.ts && ts-node --transpile-only tests/homework.test.ts && ts-node --transpile-only tests/organization.test.ts && ts-node --transpile-only tests/rateLimit.test.ts",
     "retrain-model": "ts-node --transpile-only ../scripts/retrain_homework_model.ts"
   },
   "keywords": [],
@@ -16,12 +16,13 @@
     "cors": "^2.8.5",
     "dotenv": "^17.2.1",
     "express": "^5.1.0",
+    "express-rate-limit": "^8.0.1",
     "express-validator": "^7.2.1",
     "helmet": "^8.1.0",
     "jsonwebtoken": "^9.0.2",
+    "knex": "^3.1.0",
     "ldapjs": "^2.3.3",
     "morgan": "^1.10.1",
-    "knex": "^3.1.0",
     "passport-saml": "^3.2.4",
     "pg": "^8.11.5"
   },
@@ -30,9 +31,9 @@
     "@types/express": "^5.0.3",
     "@types/morgan": "^1.9.10",
     "@types/node": "^24.2.0",
+    "@types/pg": "^8.11.6",
     "nodemon": "^3.1.10",
     "ts-node": "^10.9.2",
-    "typescript": "^5.9.2",
-    "@types/pg": "^8.11.6"
+    "typescript": "^5.9.2"
   }
 }

--- a/backend/src/middleware/rateLimit.middleware.ts
+++ b/backend/src/middleware/rateLimit.middleware.ts
@@ -1,0 +1,11 @@
+import rateLimit from 'express-rate-limit';
+
+const max = parseInt(process.env.RATE_LIMIT_MAX || '100', 10);
+
+export const externalRateLimiter = rateLimit({
+  windowMs: 60 * 1000,
+  max,
+  standardHeaders: true,
+  legacyHeaders: false,
+});
+

--- a/backend/src/repositories/apiKey.repository.ts
+++ b/backend/src/repositories/apiKey.repository.ts
@@ -27,6 +27,17 @@ export class ApiKeyRepository {
   async revoke(key: string): Promise<void> {
     await db<ApiKey>('api_keys').where({ key }).update({ revoked: true });
   }
+
+  async listAll(): Promise<ApiKey[]> {
+    return db<ApiKey>('api_keys').select(
+      'id',
+      'key',
+      'partner_name',
+      'revoked',
+      'created_at',
+      'updated_at',
+    );
+  }
 }
 
 export const apiKeyRepository = new ApiKeyRepository();

--- a/backend/src/routes/developer.routes.ts
+++ b/backend/src/routes/developer.routes.ts
@@ -1,0 +1,36 @@
+import { Router } from 'express';
+import { apiKeyService } from '../services/apiKey.service';
+
+const router = Router();
+
+router.get('/', async (_req, res) => {
+  const keys = await apiKeyService.listKeys();
+  const rows = keys
+    .map(
+      k => `<tr><td>${k.partner_name}</td><td>${k.key}</td><td>${k.revoked}</td></tr>`,
+    )
+    .join('');
+  res.send(`<!DOCTYPE html><html><head><title>Developer Portal</title></head><body><h1>API Keys</h1><table border="1"><tr><th>Partner</th><th>Key</th><th>Revoked</th></tr>${rows}</table><h2>Create Key</h2><form id="createForm"><input name="partner" placeholder="Partner Name"/><button type="submit">Create</button></form><script>document.getElementById('createForm').addEventListener('submit',async e=>{e.preventDefault();const partner=e.target.partner.value;const res=await fetch('/api/developer/keys',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({partnerName:partner})});const data=await res.json();alert('Key: '+data.data.key);location.reload();});</script></body></html>`);
+});
+
+router.get('/keys', async (_req, res) => {
+  const keys = await apiKeyService.listKeys();
+  res.success(keys);
+});
+
+router.post('/keys', async (req, res) => {
+  const { partnerName } = req.body;
+  if (!partnerName) {
+    res.error('partnerName required', 400);
+    return;
+  }
+  const key = await apiKeyService.generateKey(partnerName);
+  res.success({ key });
+});
+
+router.post('/keys/:key/revoke', async (req, res) => {
+  await apiKeyService.revokeKey(req.params.key);
+  res.success({ revoked: true });
+});
+
+export default router;

--- a/backend/src/routes/external.routes.ts
+++ b/backend/src/routes/external.routes.ts
@@ -1,8 +1,11 @@
 import { Router } from 'express';
 import { verifyApiKey } from '../middleware/apiKey.middleware';
+import { externalRateLimiter } from '../middleware/rateLimit.middleware';
 import { userRepository } from '../repositories/user.repository';
 
 const router = Router();
+
+router.use(externalRateLimiter);
 
 router.get('/health', verifyApiKey, (_req, res) => {
   res.success({ status: 'ok' });

--- a/backend/src/routes/index.ts
+++ b/backend/src/routes/index.ts
@@ -5,6 +5,7 @@ import homeworkRoutes from './homework.routes';
 import schoolRoutes from './school.routes';
 import organizationRoutes from './organization.routes';
 import externalRoutes from './external.routes';
+import developerRoutes from './developer.routes';
 
 const router = Router();
 
@@ -14,5 +15,6 @@ router.use('/homework', homeworkRoutes);
 router.use('/school', schoolRoutes);
 router.use('/organizations', organizationRoutes);
 router.use('/external', externalRoutes);
+router.use('/developer', developerRoutes);
 
 export default router;

--- a/backend/src/services/apiKey.service.ts
+++ b/backend/src/services/apiKey.service.ts
@@ -16,6 +16,10 @@ class ApiKeyService {
   async revokeKey(key: string): Promise<void> {
     await apiKeyRepository.revoke(key);
   }
+
+  async listKeys() {
+    return apiKeyRepository.listAll();
+  }
 }
 
 export const apiKeyService = new ApiKeyService();

--- a/backend/tests/rateLimit.test.ts
+++ b/backend/tests/rateLimit.test.ts
@@ -1,0 +1,27 @@
+import assert from 'node:assert';
+import { AddressInfo } from 'node:net';
+
+process.env.RATE_LIMIT_MAX = '5';
+process.env.DATABASE_URL = 'postgres://user:pass@localhost:5432/test';
+process.env.JWT_SECRET = 'test-secret';
+process.env.JWT_REFRESH_SECRET = 'test-refresh';
+process.env.EMAIL_SERVICE_KEY = 'test-email';
+process.env.NODE_ENV = 'test';
+
+import app from '../src/index';
+
+const server = app.listen(0, async () => {
+  const port = (server.address() as AddressInfo).port;
+  const baseUrl = `http://localhost:${port}`;
+
+  for (let i = 0; i < 5; i++) {
+    const res = await fetch(`${baseUrl}/api/external/health`);
+    assert.strictEqual(res.status, 401);
+  }
+
+  const res6 = await fetch(`${baseUrl}/api/external/health`);
+  assert.strictEqual(res6.status, 429);
+
+  console.log('Rate limit test passed');
+  server.close();
+});

--- a/backend/third_party_api.md
+++ b/backend/third_party_api.md
@@ -7,4 +7,13 @@ Alle Anfragen müssen den Header `x-api-key` mit einem gültigen Schlüssel enth
 - `GET /api/external/health` – Prüft den API-Status.
 - `GET /api/external/users/:id` – Liefert Basisinformationen zu einem Benutzer.
 
+## Developer-Portal
+- `GET /api/developer` – Einfache Oberfläche zur Verwaltung von API-Schlüsseln.
+- `GET /api/developer/keys` – Liste aller Schlüssel.
+- `POST /api/developer/keys` – Erstellt einen neuen Schlüssel (`{ partnerName }`).
+- `POST /api/developer/keys/:key/revoke` – Widerruft einen Schlüssel.
+
+## Rate Limiting
+Alle externen Endpunkte sind auf 100 Anfragen pro Minute begrenzt. Für Tests kann dies über die Umgebungsvariable `RATE_LIMIT_MAX` angepasst werden.
+
 Weitere Endpunkte folgen.

--- a/codex/daten/changelog.md
+++ b/codex/daten/changelog.md
@@ -357,3 +357,8 @@
 - `ApiKeyRepository`, `ApiKeyService`, Middleware und externe Routen implementiert
 - Dokumentation `backend/third_party_api.md` erstellt
 - Roadmap und Prompt aktualisiert
+
+### Phase 4: Developer-Portal & Rate-Limiting - 2025-08-10
+- Developer-Portal mit HTML-Oberfläche und API-Routen zur Verwaltung von Schlüsseln erstellt
+- Rate-Limiting für externe Endpunkte mit `express-rate-limit` hinzugefügt
+- Test für Rate-Limiting und Dokumentation erweitert

--- a/codex/daten/prompt.md
+++ b/codex/daten/prompt.md
@@ -1,4 +1,4 @@
-# Nächster Schritt: Phase 4 – Developer-Portal & Rate-Limiting
+# Nächster Schritt: Phase 4 – API-Dokumentation & Beispielskripte
 
 ## Status
 - Phase 0 abgeschlossen ✓
@@ -15,21 +15,22 @@
 - `/codex/AGENTS.md`
 - `/codex/daten/roadmap.md`
 - `/codex/daten/changelog.md`
+- `backend/third_party_api.md`
 
 ## Nächste Aufgabe
-Developer-Portal und Rate-Limiting implementieren.
+API-Dokumentation für Drittanbieter erweitern und Beispielskript zur Nutzung des Developer-Portals erstellen.
 
 ### Vorbereitungen
-- Bestehenden API-Key-Service und externe Routen analysieren.
-- Recherche zu `express-rate-limit`.
+- Bestehende Dokumentation prüfen.
+- Anforderungen für Beispielskript sammeln.
 
 ### Implementierungsschritte
-- Developer-Portal zur Verwaltung von API-Schlüsseln aufsetzen.
-- Rate-Limiting für externe Endpunkte hinzufügen.
+- `backend/third_party_api.md` um detaillierte Anleitung erweitern.
+- Skript `scripts/example_api_client.ts` erstellen, das API-Key generiert und Abfrage durchführt.
 
 ### Validierung
 - `python -m py_compile` auf geänderten Python-Dateien ausführen.
-- `flutter test` und `npm test` ausführen (falls vorhanden).
+- `npm test` und `flutter test` ausführen (falls vorhanden).
 
 ### Selbstgenerierung
 - Nach Abschluss dieses Schrittes automatisch den nächsten Prompt in `/codex/daten/prompt.md` schreiben.

--- a/codex/daten/roadmap.md
+++ b/codex/daten/roadmap.md
@@ -352,5 +352,5 @@ Details: Endpoint liefert aktuelle Modellversion und letztes Trainingsdatum.
 
 ### Milestone 1: Drittanbieter-API
 - [x] Öffentliche API-Endpunkte und Authentifizierung mit API-Schlüsseln
-- [ ] Developer-Portal und Rate-Limiting implementieren
+- [x] Developer-Portal und Rate-Limiting implementieren
 


### PR DESCRIPTION
## Summary
- add developer portal with HTML interface and key management endpoints
- apply express-rate-limit middleware to external API routes
- document developer portal and rate limiting, add related test

## Testing
- `python -m py_compile` (no files)
- `flutter test` *(fails: command not found)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68961c2e9b48832e8be41b686b8cc59e