### PR TITLE
docs: expand third-party API docs and add example client

### DIFF
--- a/backend/third_party_api.md
+++ b/backend/third_party_api.md
@@ -1,11 +1,38 @@
 # Drittanbieter API
 
 ## Authentifizierung
-Alle Anfragen müssen den Header `x-api-key` mit einem gültigen Schlüssel enthalten.
+Alle Anfragen müssen den Header `x-api-key` mit einem gültigen Schlüssel enthalten. Schlüssel können über das Developer-Portal generiert werden.
+
+### API-Key erstellen
+`POST /api/developer/keys`
+
+Body:
+```json
+{ "partnerName": "Acme Corp" }
+```
+
+Antwort:
+```json
+{ "key": "GENERATED_KEY" }
+```
 
 ## Endpunkte
 - `GET /api/external/health` – Prüft den API-Status.
 - `GET /api/external/users/:id` – Liefert Basisinformationen zu einem Benutzer.
+
+### Beispielaufrufe
+```bash
+# Gesundheitscheck
+curl -H "x-api-key: <API_KEY>" http://localhost:3000/api/external/health
+
+# Benutzer abrufen
+curl -H "x-api-key: <API_KEY>" http://localhost:3000/api/external/users/123
+```
+
+## Fehlercodes
+- `401 Unauthorized` – Fehlender oder ungültiger API-Key.
+- `404 Not Found` – Ressource existiert nicht.
+- `429 Too Many Requests` – Rate Limit überschritten.
 
 ## Developer-Portal
 - `GET /api/developer` – Einfache Oberfläche zur Verwaltung von API-Schlüsseln.
@@ -16,4 +43,8 @@ Alle Anfragen müssen den Header `x-api-key` mit einem gültigen Schlüssel enth
 ## Rate Limiting
 Alle externen Endpunkte sind auf 100 Anfragen pro Minute begrenzt. Für Tests kann dies über die Umgebungsvariable `RATE_LIMIT_MAX` angepasst werden.
 
+## Beispielskript
+Führe `ts-node scripts/example_api_client.ts` aus, um API-Key-Erstellung und Anfragen zu demonstrieren. Das Skript erzeugt alle benötigten Artefakte automatisch; es werden keine Binärdateien im Repository gespeichert.
+
 Weitere Endpunkte folgen.
+

--- a/codex/daten/changelog.md
+++ b/codex/daten/changelog.md
@@ -362,3 +362,8 @@
 - Developer-Portal mit HTML-Oberfläche und API-Routen zur Verwaltung von Schlüsseln erstellt
 - Rate-Limiting für externe Endpunkte mit `express-rate-limit` hinzugefügt
 - Test für Rate-Limiting und Dokumentation erweitert
+
+### Phase 4: API-Dokumentation & Beispielskripte - 2025-08-10
+- Dokumentation `backend/third_party_api.md` um Authentifizierungsbeispiele, Fehlercodes und Nutzungshinweise erweitert
+- Skript `scripts/example_api_client.ts` demonstriert API-Key-Erstellung und API-Abfragen
+- Roadmap und Prompt aktualisiert

--- a/codex/daten/prompt.md
+++ b/codex/daten/prompt.md
@@ -1,4 +1,4 @@
-# Nächster Schritt: Phase 4 – API-Dokumentation & Beispielskripte
+# Nächster Schritt: Phase 4 – Automatisierte API-Tests
 
 ## Status
 - Phase 0 abgeschlossen ✓
@@ -9,6 +9,7 @@
 - Phase 3 Milestone 3 abgeschlossen ✓
 - Phase 3 Milestone 4 abgeschlossen ✓
 - Phase 4 Milestone 1 abgeschlossen ✓
+- Phase 4 Milestone 2 abgeschlossen ✓
 
 ## Referenzen
 - `/README.md`
@@ -16,17 +17,18 @@
 - `/codex/daten/roadmap.md`
 - `/codex/daten/changelog.md`
 - `backend/third_party_api.md`
+- `scripts/example_api_client.ts`
 
 ## Nächste Aufgabe
-API-Dokumentation für Drittanbieter erweitern und Beispielskript zur Nutzung des Developer-Portals erstellen.
+Automatisierte Tests für die Drittanbieter-API hinzufügen.
 
 ### Vorbereitungen
-- Bestehende Dokumentation prüfen.
-- Anforderungen für Beispielskript sammeln.
+- API-Dokumentation und vorhandene Tests prüfen.
+- Testfälle für authentifizierte und nicht authentifizierte Zugriffe definieren.
 
 ### Implementierungsschritte
-- `backend/third_party_api.md` um detaillierte Anleitung erweitern.
-- Skript `scripts/example_api_client.ts` erstellen, das API-Key generiert und Abfrage durchführt.
+- Datei `backend/tests/external_api.test.ts` erstellen und Endpunkte mit gültigem sowie ungültigem API-Key testen.
+- `package.json` im Backend um Skript `test:external` ergänzen, das die neuen Tests ausführt.
 
 ### Validierung
 - `python -m py_compile` auf geänderten Python-Dateien ausführen.
@@ -36,3 +38,4 @@ API-Dokumentation für Drittanbieter erweitern und Beispielskript zur Nutzung de
 - Nach Abschluss dieses Schrittes automatisch den nächsten Prompt in `/codex/daten/prompt.md` schreiben.
 
 *Hinweis: Codex kann keine Binärdateien mergen. Benötigte Dateien werden durch Skripte generiert. Halte den Codeumfang dieses Sprints unter 500 Zeilen.*
+

--- a/codex/daten/roadmap.md
+++ b/codex/daten/roadmap.md
@@ -354,3 +354,7 @@ Details: Endpoint liefert aktuelle Modellversion und letztes Trainingsdatum.
 - [x] Öffentliche API-Endpunkte und Authentifizierung mit API-Schlüsseln
 - [x] Developer-Portal und Rate-Limiting implementieren
 
+### Milestone 2: API-Dokumentation & Beispielskripte
+- [x] Dokumentation der Drittanbieter-API erweitern
+- [x] Beispielskript zur Nutzung des Developer-Portals erstellen
+

--- a/scripts/example_api_client.ts
+++ b/scripts/example_api_client.ts
@@ -1,0 +1,55 @@
+/**
+ * Beispielskript zur Verwendung der Drittanbieter-API.
+ *
+ * Das Skript erzeugt einen neuen API-Key über das Developer-Portal
+ * und ruft anschließend einen Benutzerendpunkt mit diesem Schlüssel auf.
+ * Es werden keine Binärdateien eingecheckt – benötigte Artefakte
+ * entstehen erst beim Ausführen.
+ */
+
+import { randomUUID } from 'crypto';
+
+const API_BASE = process.env.API_BASE_URL ?? 'http://localhost:3000';
+
+async function createApiKey(partnerName: string): Promise<string> {
+  const res = await fetch(`${API_BASE}/api/developer/keys`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ partnerName }),
+  });
+
+  if (!res.ok) {
+    throw new Error(`Failed to create API key: ${res.status} ${res.statusText}`);
+  }
+
+  const data = (await res.json()) as { key: string };
+  return data.key;
+}
+
+async function getUser(id: string, apiKey: string) {
+  const res = await fetch(`${API_BASE}/api/external/users/${id}`, {
+    headers: { 'x-api-key': apiKey },
+  });
+
+  if (!res.ok) {
+    throw new Error(`Request failed: ${res.status} ${res.statusText}`);
+  }
+
+  return res.json();
+}
+
+async function main() {
+  try {
+    const partner = process.argv[2] ?? `example-${randomUUID()}`;
+    const apiKey = await createApiKey(partner);
+    console.log('Generated API key:', apiKey);
+
+    const user = await getUser('1', apiKey);
+    console.log('Fetched user:', user);
+  } catch (err) {
+    console.error('Example client failed:', err);
+  }
+}
+
+main();
+


### PR DESCRIPTION
## Summary
- document third-party API authentication, endpoints, errors, and usage
- add TypeScript example script for generating keys and calling external endpoints
- update roadmap, changelog, and next-step prompt

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `npm test`
- `flutter test` *(fails: command not found: flutter)*

------
https://chatgpt.com/codex/tasks/task_e_6896202a76f0832ead920d57b758d39f