### PR TITLE
Add external API key tests and roadmap update

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "scripts": {
     "test": "ts-node --transpile-only tests/security.test.ts && ts-node --transpile-only tests/homework.test.ts && ts-node --transpile-only tests/organization.test.ts && ts-node --transpile-only tests/rateLimit.test.ts",
-    "retrain-model": "ts-node --transpile-only ../scripts/retrain_homework_model.ts"
+    "retrain-model": "ts-node --transpile-only ../scripts/retrain_homework_model.ts",
+    "test:external": "ts-node --transpile-only tests/external_api.test.ts"
   },
   "keywords": [],
   "author": "",

--- a/backend/tests/external_api.test.ts
+++ b/backend/tests/external_api.test.ts
@@ -1,0 +1,34 @@
+import assert from 'node:assert';
+import { AddressInfo } from 'node:net';
+
+process.env.DATABASE_URL = 'postgres://user:pass@localhost:5432/test';
+process.env.JWT_SECRET = 'test-secret';
+process.env.JWT_REFRESH_SECRET = 'test-refresh';
+process.env.EMAIL_SERVICE_KEY = 'test-email';
+process.env.NODE_ENV = 'test';
+
+import app from '../src/index';
+import { apiKeyService } from '../src/services/apiKey.service';
+
+(apiKeyService as any).validateKey = async (key: string) => key === 'valid-key';
+
+const server = app.listen(0, async () => {
+  const port = (server.address() as AddressInfo).port;
+  const baseUrl = `http://localhost:${port}`;
+
+  const ok = await fetch(`${baseUrl}/api/external/health`, {
+    headers: { 'x-api-key': 'valid-key' },
+  });
+  assert.strictEqual(ok.status, 200);
+
+  const bad = await fetch(`${baseUrl}/api/external/health`, {
+    headers: { 'x-api-key': 'invalid-key' },
+  });
+  assert.strictEqual(bad.status, 403);
+
+  const missing = await fetch(`${baseUrl}/api/external/health`);
+  assert.strictEqual(missing.status, 401);
+
+  console.log('External API tests passed');
+  server.close();
+});

--- a/codex/daten/changelog.md
+++ b/codex/daten/changelog.md
@@ -367,3 +367,8 @@
 - Dokumentation `backend/third_party_api.md` um Authentifizierungsbeispiele, Fehlercodes und Nutzungshinweise erweitert
 - Skript `scripts/example_api_client.ts` demonstriert API-Key-Erstellung und API-Abfragen
 - Roadmap und Prompt aktualisiert
+
+### Phase 4: Automatisierte API-Tests - 2025-08-10
+- Testdatei `backend/tests/external_api.test.ts` prüft externe Endpunkte mit gültigem und ungültigem API-Key
+- NPM-Skript `test:external` zum Ausführen der externen API-Tests hinzugefügt
+- Roadmap und Prompt aktualisiert

--- a/codex/daten/prompt.md
+++ b/codex/daten/prompt.md
@@ -1,4 +1,4 @@
-# Nächster Schritt: Phase 4 – Automatisierte API-Tests
+# Nächster Schritt: Phase 4 – Client-SDK für Drittanbieter-API
 
 ## Status
 - Phase 0 abgeschlossen ✓
@@ -10,6 +10,7 @@
 - Phase 3 Milestone 4 abgeschlossen ✓
 - Phase 4 Milestone 1 abgeschlossen ✓
 - Phase 4 Milestone 2 abgeschlossen ✓
+- Phase 4 Milestone 3 abgeschlossen ✓
 
 ## Referenzen
 - `/README.md`
@@ -17,18 +18,17 @@
 - `/codex/daten/roadmap.md`
 - `/codex/daten/changelog.md`
 - `backend/third_party_api.md`
-- `scripts/example_api_client.ts`
 
 ## Nächste Aufgabe
-Automatisierte Tests für die Drittanbieter-API hinzufügen.
+Client-SDK für die Drittanbieter-API erstellen.
 
 ### Vorbereitungen
-- API-Dokumentation und vorhandene Tests prüfen.
-- Testfälle für authentifizierte und nicht authentifizierte Zugriffe definieren.
+- Anforderungen an Client-Bibliotheken prüfen.
+- Zielplattform (z.B. TypeScript) festlegen.
 
 ### Implementierungsschritte
-- Datei `backend/tests/external_api.test.ts` erstellen und Endpunkte mit gültigem sowie ungültigem API-Key testen.
-- `package.json` im Backend um Skript `test:external` ergänzen, das die neuen Tests ausführt.
+- SDK-Grundgerüst im Ordner `backend/sdk/` erstellen.
+- Beispiel-Funktion für `GET /api/external/health` implementieren.
 
 ### Validierung
 - `python -m py_compile` auf geänderten Python-Dateien ausführen.
@@ -38,4 +38,3 @@ Automatisierte Tests für die Drittanbieter-API hinzufügen.
 - Nach Abschluss dieses Schrittes automatisch den nächsten Prompt in `/codex/daten/prompt.md` schreiben.
 
 *Hinweis: Codex kann keine Binärdateien mergen. Benötigte Dateien werden durch Skripte generiert. Halte den Codeumfang dieses Sprints unter 500 Zeilen.*
-

--- a/codex/daten/roadmap.md
+++ b/codex/daten/roadmap.md
@@ -358,3 +358,11 @@ Details: Endpoint liefert aktuelle Modellversion und letztes Trainingsdatum.
 - [x] Dokumentation der Drittanbieter-API erweitern
 - [x] Beispielskript zur Nutzung des Developer-Portals erstellen
 
+### Milestone 3: Automatisierte API-Tests
+- [x] Tests der externen Endpunkte mit gültigem und ungültigem API-Key
+- [x] NPM-Skript `test:external` zum Ausführen der Tests hinzufügen
+
+### Milestone 4: Client-SDK für Drittanbieter-API
+- [ ] JavaScript-SDK mit Beispielaufrufen bereitstellen
+- [ ] TypeScript-Typdefinitionen veröffentlichen
+


### PR DESCRIPTION
## Summary
- add external API tests verifying valid and invalid API key handling
- expose `test:external` npm script and update roadmap/changelog
- generate next development prompt for client SDK milestone

## Testing
- `npm test`
- `npm run test:external`
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68962425a82c832e890237db5c191d34