### PR TITLE
feat: scaffold third-party API SDK

### DIFF
--- a/backend/sdk/index.ts
+++ b/backend/sdk/index.ts
@@ -1,0 +1,38 @@
+import { request as httpsRequest } from 'https';
+import { request as httpRequest } from 'http';
+import { URL } from 'url';
+
+export class ThirdPartyApiClient {
+  constructor(private baseUrl: string, private apiKey: string) {}
+
+  async healthCheck(): Promise<any> {
+    const url = new URL('/api/external/health', this.baseUrl);
+    const requester = url.protocol === 'https:' ? httpsRequest : httpRequest;
+    return new Promise((resolve, reject) => {
+      const req = requester(
+        url,
+        {
+          method: 'GET',
+          headers: { 'x-api-key': this.apiKey },
+        },
+        res => {
+          let data = '';
+          res.on('data', chunk => (data += chunk));
+          res.on('end', () => {
+            if (res.statusCode && res.statusCode >= 200 && res.statusCode < 300) {
+              try {
+                resolve(JSON.parse(data));
+              } catch {
+                resolve(data);
+              }
+            } else {
+              reject(new Error(`Request failed with status ${res.statusCode}`));
+            }
+          });
+        }
+      );
+      req.on('error', reject);
+      req.end();
+    });
+  }
+}

--- a/codex/daten/changelog.md
+++ b/codex/daten/changelog.md
@@ -372,3 +372,8 @@
 - Testdatei `backend/tests/external_api.test.ts` prüft externe Endpunkte mit gültigem und ungültigem API-Key
 - NPM-Skript `test:external` zum Ausführen der externen API-Tests hinzugefügt
 - Roadmap und Prompt aktualisiert
+
+### Phase 4: Client-SDK für Drittanbieter-API - 2025-08-10
+- SDK-Grundgerüst unter `backend/sdk/` mit `healthCheck` Funktion erstellt
+- Skript `scripts/build_sdk.sh` generiert JavaScript-Dateien automatisch
+- Roadmap und Prompt aktualisiert

--- a/codex/daten/prompt.md
+++ b/codex/daten/prompt.md
@@ -1,4 +1,4 @@
-# Nächster Schritt: Phase 4 – Client-SDK für Drittanbieter-API
+# Nächster Schritt: Phase 4 – TypeScript-Typdefinitionen für Client-SDK
 
 ## Status
 - Phase 0 abgeschlossen ✓
@@ -11,6 +11,7 @@
 - Phase 4 Milestone 1 abgeschlossen ✓
 - Phase 4 Milestone 2 abgeschlossen ✓
 - Phase 4 Milestone 3 abgeschlossen ✓
+- Phase 4 Milestone 4 (JS-SDK) abgeschlossen ✓
 
 ## Referenzen
 - `/README.md`
@@ -20,15 +21,15 @@
 - `backend/third_party_api.md`
 
 ## Nächste Aufgabe
-Client-SDK für die Drittanbieter-API erstellen.
+TypeScript-Typdefinitionen für das Client-SDK veröffentlichen.
 
 ### Vorbereitungen
-- Anforderungen an Client-Bibliotheken prüfen.
-- Zielplattform (z.B. TypeScript) festlegen.
+- Bestehenden SDK-Code analysieren.
+- Build-Prozess für Typdefinitionen prüfen.
 
 ### Implementierungsschritte
-- SDK-Grundgerüst im Ordner `backend/sdk/` erstellen.
-- Beispiel-Funktion für `GET /api/external/health` implementieren.
+- `build_sdk.sh` erweitern, um `.d.ts` Dateien zu erzeugen.
+- Typdefinitionen im Ordner `backend/sdk/dist` ablegen.
 
 ### Validierung
 - `python -m py_compile` auf geänderten Python-Dateien ausführen.

--- a/codex/daten/roadmap.md
+++ b/codex/daten/roadmap.md
@@ -363,6 +363,6 @@ Details: Endpoint liefert aktuelle Modellversion und letztes Trainingsdatum.
 - [x] NPM-Skript `test:external` zum Ausführen der Tests hinzufügen
 
 ### Milestone 4: Client-SDK für Drittanbieter-API
-- [ ] JavaScript-SDK mit Beispielaufrufen bereitstellen
+- [x] JavaScript-SDK mit Beispielaufrufen bereitstellen
 - [ ] TypeScript-Typdefinitionen veröffentlichen
 

--- a/scripts/build_sdk.sh
+++ b/scripts/build_sdk.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -e
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+SDK_DIR="$ROOT_DIR/backend/sdk"
+DIST_DIR="$SDK_DIR/dist"
+
+mkdir -p "$DIST_DIR"
+
+cd "$ROOT_DIR/backend"
+npx tsc "$SDK_DIR/index.ts" --module commonjs --target ES2020 --lib ES2020 --moduleResolution node --types node --outDir "$DIST_DIR"
+echo "SDK built at $DIST_DIR"


### PR DESCRIPTION
## Summary
- add TypeScript ThirdPartyApiClient with healthCheck method
- add build script to generate distributable files
- update roadmap, changelog and prompt for upcoming TypeScript definitions

## Testing
- `./scripts/build_sdk.sh`
- `cd backend && npm test`
- `cd flutter_app && flutter test` *(fails: command not found)*
- `python -m py_compile` *(fails: filenames required)*

------
https://chatgpt.com/codex/tasks/task_e_68962821deb0832eb7bbc4776f1f024f