### PR TITLE
feat: generate SDK type definitions

### DIFF
--- a/backend/sdk/index.ts
+++ b/backend/sdk/index.ts
@@ -2,10 +2,14 @@ import { request as httpsRequest } from 'https';
 import { request as httpRequest } from 'http';
 import { URL } from 'url';
 
+export interface HealthResponse {
+  status: string;
+}
+
 export class ThirdPartyApiClient {
   constructor(private baseUrl: string, private apiKey: string) {}
 
-  async healthCheck(): Promise<any> {
+  async healthCheck(): Promise<HealthResponse> {
     const url = new URL('/api/external/health', this.baseUrl);
     const requester = url.protocol === 'https:' ? httpsRequest : httpRequest;
     return new Promise((resolve, reject) => {
@@ -21,9 +25,9 @@ export class ThirdPartyApiClient {
           res.on('end', () => {
             if (res.statusCode && res.statusCode >= 200 && res.statusCode < 300) {
               try {
-                resolve(JSON.parse(data));
+                resolve(JSON.parse(data) as HealthResponse);
               } catch {
-                resolve(data);
+                reject(new Error('Invalid JSON in health check response'));
               }
             } else {
               reject(new Error(`Request failed with status ${res.statusCode}`));

--- a/backend/third_party_api.md
+++ b/backend/third_party_api.md
@@ -46,5 +46,8 @@ Alle externen Endpunkte sind auf 100 Anfragen pro Minute begrenzt. Für Tests ka
 ## Beispielskript
 Führe `ts-node scripts/example_api_client.ts` aus, um API-Key-Erstellung und Anfragen zu demonstrieren. Das Skript erzeugt alle benötigten Artefakte automatisch; es werden keine Binärdateien im Repository gespeichert.
 
+## Client SDK
+Das Skript `scripts/build_sdk.sh` erzeugt das JavaScript-SDK sowie die zugehörigen TypeScript-Typdefinitionen (`.d.ts`) im Verzeichnis `backend/sdk/dist`. Die generierten Dateien werden nicht versioniert und müssen vor der Verwendung erstellt werden.
+
 Weitere Endpunkte folgen.
 

--- a/codex/daten/changelog.md
+++ b/codex/daten/changelog.md
@@ -377,3 +377,9 @@
 - SDK-Grundgerüst unter `backend/sdk/` mit `healthCheck` Funktion erstellt
 - Skript `scripts/build_sdk.sh` generiert JavaScript-Dateien automatisch
 - Roadmap und Prompt aktualisiert
+
+### Phase 4: TypeScript-Typdefinitionen für Client-SDK - 2025-08-10
+- `build_sdk.sh` erzeugt nun `.d.ts` Dateien im SDK `dist` Ordner
+- `ThirdPartyApiClient.healthCheck` liefert typisierten `HealthResponse`
+- Dokumentation zu `backend/third_party_api.md` um Hinweis auf SDK-Build erweitert
+- Roadmap und Prompt aktualisiert

--- a/codex/daten/prompt.md
+++ b/codex/daten/prompt.md
@@ -1,4 +1,4 @@
-# Nächster Schritt: Phase 4 – TypeScript-Typdefinitionen für Client-SDK
+# Nächster Schritt: Roadmap abgeschlossen – neue Anforderungen ausstehend
 
 ## Status
 - Phase 0 abgeschlossen ✓
@@ -11,7 +11,7 @@
 - Phase 4 Milestone 1 abgeschlossen ✓
 - Phase 4 Milestone 2 abgeschlossen ✓
 - Phase 4 Milestone 3 abgeschlossen ✓
-- Phase 4 Milestone 4 (JS-SDK) abgeschlossen ✓
+- Phase 4 Milestone 4 abgeschlossen ✓
 
 ## Referenzen
 - `/README.md`
@@ -21,21 +21,18 @@
 - `backend/third_party_api.md`
 
 ## Nächste Aufgabe
-TypeScript-Typdefinitionen für das Client-SDK veröffentlichen.
+Keine weiteren Aufgaben definiert. Bitte neue Anforderungen in der Roadmap ergänzen.
 
 ### Vorbereitungen
-- Bestehenden SDK-Code analysieren.
-- Build-Prozess für Typdefinitionen prüfen.
+- Roadmap auf kommende Meilensteine prüfen.
 
 ### Implementierungsschritte
-- `build_sdk.sh` erweitern, um `.d.ts` Dateien zu erzeugen.
-- Typdefinitionen im Ordner `backend/sdk/dist` ablegen.
+- Auf neue Aufgaben warten.
 
 ### Validierung
-- `python -m py_compile` auf geänderten Python-Dateien ausführen.
-- `npm test` und `flutter test` ausführen (falls vorhanden).
+- Keine.
 
 ### Selbstgenerierung
-- Nach Abschluss dieses Schrittes automatisch den nächsten Prompt in `/codex/daten/prompt.md` schreiben.
+- Nach Ergänzung neuer Aufgaben diesen Prompt aktualisieren.
 
 *Hinweis: Codex kann keine Binärdateien mergen. Benötigte Dateien werden durch Skripte generiert. Halte den Codeumfang dieses Sprints unter 500 Zeilen.*

--- a/codex/daten/roadmap.md
+++ b/codex/daten/roadmap.md
@@ -364,5 +364,5 @@ Details: Endpoint liefert aktuelle Modellversion und letztes Trainingsdatum.
 
 ### Milestone 4: Client-SDK für Drittanbieter-API
 - [x] JavaScript-SDK mit Beispielaufrufen bereitstellen
-- [ ] TypeScript-Typdefinitionen veröffentlichen
+- [x] TypeScript-Typdefinitionen veröffentlichen
 

--- a/scripts/build_sdk.sh
+++ b/scripts/build_sdk.sh
@@ -8,5 +8,5 @@ DIST_DIR="$SDK_DIR/dist"
 mkdir -p "$DIST_DIR"
 
 cd "$ROOT_DIR/backend"
-npx tsc "$SDK_DIR/index.ts" --module commonjs --target ES2020 --lib ES2020 --moduleResolution node --types node --outDir "$DIST_DIR"
+npx tsc "$SDK_DIR/index.ts" --module commonjs --target ES2020 --lib ES2020 --moduleResolution node --types node --declaration --outDir "$DIST_DIR"
 echo "SDK built at $DIST_DIR"


### PR DESCRIPTION
## Summary
- add HealthResponse interface and typed healthCheck in SDK
- extend build_sdk.sh to emit TypeScript declarations
- document SDK build and update roadmap, changelog, and prompt

## Testing
- `scripts/build_sdk.sh`
- `npm test`
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68962c1d508c832eb2f268cfc2ee5e6d