### PR TITLE
docs: add phase 5 roadmap

### DIFF
--- a/codex/daten/changelog.md
+++ b/codex/daten/changelog.md
@@ -383,3 +383,6 @@
 - `ThirdPartyApiClient.healthCheck` liefert typisierten `HealthResponse`
 - Dokumentation zu `backend/third_party_api.md` um Hinweis auf SDK-Build erweitert
 - Roadmap und Prompt aktualisiert
+### Phase 5: Roadmap Planung - 2025-08-10
+- Phase 5 mit Gamification- und Adaptive-Learning-Zielen in `roadmap.md` ergänzt
+- `prompt.md` für nächsten Schritt angepasst

--- a/codex/daten/prompt.md
+++ b/codex/daten/prompt.md
@@ -1,4 +1,4 @@
-# Nächster Schritt: Roadmap abgeschlossen – neue Anforderungen ausstehend
+# Nächster Schritt: Phase 5 Milestone 1 – Gamification Engine
 
 ## Status
 - Phase 0 abgeschlossen ✓
@@ -12,6 +12,8 @@
 - Phase 4 Milestone 2 abgeschlossen ✓
 - Phase 4 Milestone 3 abgeschlossen ✓
 - Phase 4 Milestone 4 abgeschlossen ✓
+- Phase 5 Milestone 1 offen ☐
+- Phase 5 Milestone 2 offen ☐
 
 ## Referenzen
 - `/README.md`
@@ -21,18 +23,19 @@
 - `backend/third_party_api.md`
 
 ## Nächste Aufgabe
-Keine weiteren Aufgaben definiert. Bitte neue Anforderungen in der Roadmap ergänzen.
+Phase 5 Milestone 1: Gamification Engine. Implementierung vorbereiten und Skript `scripts/generate_badge_assets.sh` für automatische Badge-Erstellung entwerfen.
 
 ### Vorbereitungen
-- Roadmap auf kommende Meilensteine prüfen.
+- Roadmap-Eintrag zu Phase 5 Milestone 1 prüfen.
 
 ### Implementierungsschritte
-- Auf neue Aufgaben warten.
+- Gamification-Engine konzipieren.
+- Skript `scripts/generate_badge_assets.sh` erstellen, das Badge-Icons generiert.
 
 ### Validierung
 - Keine.
 
 ### Selbstgenerierung
-- Nach Ergänzung neuer Aufgaben diesen Prompt aktualisieren.
+- Nach Umsetzung Prompt aktualisieren.
 
 *Hinweis: Codex kann keine Binärdateien mergen. Benötigte Dateien werden durch Skripte generiert. Halte den Codeumfang dieses Sprints unter 500 Zeilen.*

--- a/codex/daten/roadmap.md
+++ b/codex/daten/roadmap.md
@@ -366,3 +366,14 @@ Details: Endpoint liefert aktuelle Modellversion und letztes Trainingsdatum.
 - [x] JavaScript-SDK mit Beispielaufrufen bereitstellen
 - [x] TypeScript-Typdefinitionen veröffentlichen
 
+# Mrs-Unkwn Entwicklungsroadmap - Phase 5 (Monate 25-30)
+
+## Phase 5: Personalisiertes Lernen & Gamification
+
+### Milestone 1: Gamification Engine
+- [ ] Gamification-Engine zur Motivation der Lernenden implementieren
+- [ ] Skript `scripts/generate_badge_assets.sh` erzeugt Badge-Icons automatisch
+
+### Milestone 2: Adaptive Learning Paths
+- [ ] KI-gestützte Lernpfade basierend auf Nutzerleistung entwickeln
+- [ ] Skript `scripts/train_adaptive_model.sh` erstellt und trainiert notwendige Modelle


### PR DESCRIPTION
## Summary
- document Phase 5 milestones for personalized learning and gamification
- log roadmap update in changelog
- refresh prompt for upcoming Phase 5 work

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68963018b3a0832eb868995be642af9f