### PR TITLE
feat: add gamification engine base classes

### DIFF
--- a/backend/src/services/gamification/badge.manager.ts
+++ b/backend/src/services/gamification/badge.manager.ts
@@ -1,0 +1,39 @@
+import { PointsManager } from "./points.manager";
+
+interface Badge {
+  id: string;
+  description: string;
+  pointsRequired: number;
+}
+
+export class BadgeManager {
+  private badges: Badge[] = [
+    { id: "novice", description: "Earn 100 points", pointsRequired: 100 },
+    { id: "intermediate", description: "Earn 250 points", pointsRequired: 250 },
+    { id: "expert", description: "Earn 500 points", pointsRequired: 500 },
+  ];
+
+  private userBadges: Map<string, Set<string>> = new Map();
+
+  constructor(private pointsManager: PointsManager) {}
+
+  async awardEarnedBadges(userId: string): Promise<string[]> {
+    const total = await this.pointsManager.getPoints(userId);
+    const earned: string[] = [];
+    for (const badge of this.badges) {
+      if (total >= badge.pointsRequired) {
+        const set = this.userBadges.get(userId) ?? new Set<string>();
+        if (!set.has(badge.id)) {
+          set.add(badge.id);
+          this.userBadges.set(userId, set);
+          earned.push(badge.id);
+        }
+      }
+    }
+    return earned;
+  }
+
+  async getBadges(userId: string): Promise<string[]> {
+    return Array.from(this.userBadges.get(userId) ?? []);
+  }
+}

--- a/backend/src/services/gamification/index.ts
+++ b/backend/src/services/gamification/index.ts
@@ -1,0 +1,3 @@
+export * from "./points.manager";
+export * from "./level.manager";
+export * from "./badge.manager";

--- a/backend/src/services/gamification/level.manager.ts
+++ b/backend/src/services/gamification/level.manager.ts
@@ -1,0 +1,34 @@
+import { PointsManager } from "./points.manager";
+
+interface LevelConfig {
+  level: number;
+  threshold: number;
+}
+
+export class LevelManager {
+  private levels: LevelConfig[] = [
+    { level: 1, threshold: 0 },
+    { level: 2, threshold: 100 },
+    { level: 3, threshold: 250 },
+    { level: 4, threshold: 500 },
+  ];
+
+  constructor(private pointsManager: PointsManager) {}
+
+  async addPoints(userId: string, amount: number) {
+    const beforeLevel = await this.getLevel(userId);
+    const total = await this.pointsManager.addPoints(userId, amount);
+    const afterLevel = await this.getLevel(userId);
+    return {
+      points: total,
+      level: afterLevel,
+      leveledUp: afterLevel > beforeLevel,
+    };
+  }
+
+  async getLevel(userId: string): Promise<number> {
+    const total = await this.pointsManager.getPoints(userId);
+    const found = [...this.levels].reverse().find((lvl) => total >= lvl.threshold);
+    return found ? found.level : 1;
+  }
+}

--- a/backend/src/services/gamification/points.manager.ts
+++ b/backend/src/services/gamification/points.manager.ts
@@ -1,0 +1,21 @@
+export class PointsManager {
+  private points: Map<string, number> = new Map();
+
+  async addPoints(userId: string, amount: number): Promise<number> {
+    const current = this.points.get(userId) ?? 0;
+    const updated = current + amount;
+    this.points.set(userId, updated);
+    return updated;
+  }
+
+  async subtractPoints(userId: string, amount: number): Promise<number> {
+    const current = this.points.get(userId) ?? 0;
+    const updated = Math.max(0, current - amount);
+    this.points.set(userId, updated);
+    return updated;
+  }
+
+  async getPoints(userId: string): Promise<number> {
+    return this.points.get(userId) ?? 0;
+  }
+}

--- a/codex/daten/changelog.md
+++ b/codex/daten/changelog.md
@@ -391,3 +391,8 @@
 - Konzeptdokument `codex/daten/gamification_engine.md` hinzugefügt
 - Skript `scripts/generate_badge_assets.sh` erstellt, das Platzhalter-Badge-Icons generiert
 - Roadmap und Prompt aktualisiert
+
+### Phase 5: Gamification Engine Basisklassen - 2025-08-11
+- `PointsManager`, `LevelManager` und `BadgeManager` im Backend unter `services/gamification` erstellt
+- Dokumentation `gamification_engine.md` mit Link zum Badge-Generator-Skript erweitert
+- Roadmap und Prompt aktualisiert

--- a/codex/daten/gamification_engine.md
+++ b/codex/daten/gamification_engine.md
@@ -15,7 +15,7 @@
 
 ### BadgeManager
 - Vergibt Badges bei Erreichen bestimmter Meilensteine.
-- Nutzt von `scripts/generate_badge_assets.sh` erzeugte Icons.
+- Nutzt von [`scripts/generate_badge_assets.sh`](../../scripts/generate_badge_assets.sh) erzeugte Icons.
 
 ## Datenmodell
 - Tabellen/Collections für `points`, `levels`, `badges`, `user_badges`.

--- a/codex/daten/prompt.md
+++ b/codex/daten/prompt.md
@@ -1,4 +1,4 @@
-# Nächster Schritt: Phase 5 Milestone 1 – Gamification Engine
+# Nächster Schritt: Phase 5 Milestone 2 – Adaptive Learning Paths
 
 ## Status
 - Phase 0 abgeschlossen ✓
@@ -12,7 +12,7 @@
 - Phase 4 Milestone 2 abgeschlossen ✓
 - Phase 4 Milestone 3 abgeschlossen ✓
 - Phase 4 Milestone 4 abgeschlossen ✓
-- Phase 5 Milestone 1 offen ☐
+- Phase 5 Milestone 1 abgeschlossen ✓
 - Phase 5 Milestone 2 offen ☐
 
 ## Referenzen
@@ -24,14 +24,14 @@
 - `backend/third_party_api.md`
 
 ## Nächste Aufgabe
-Phase 5 Milestone 1: Gamification Engine. Grundlegende Engine implementieren und Integration vorbereiten.
+Phase 5 Milestone 2: Adaptive Learning Paths. KI-gestützte Lernpfade vorbereiten.
 
 ### Vorbereitungen
-- Roadmap-Eintrag zu Phase 5 Milestone 1 prüfen.
+- Roadmap-Eintrag zu Phase 5 Milestone 2 prüfen.
 
 ### Implementierungsschritte
-- Basisklassen für Punkte-, Level- und Badge-Management anlegen.
-- Skript `scripts/generate_badge_assets.sh` in Dokumentation verlinken.
+- Modell- und Service-Struktur für adaptive Lernpfade entwerfen.
+- Platzhalter-Skript `scripts/train_adaptive_model.sh` in Dokumentation verlinken.
 
 ### Validierung
 - Keine.

--- a/codex/daten/roadmap.md
+++ b/codex/daten/roadmap.md
@@ -371,7 +371,7 @@ Details: Endpoint liefert aktuelle Modellversion und letztes Trainingsdatum.
 ## Phase 5: Personalisiertes Lernen & Gamification
 
 ### Milestone 1: Gamification Engine
-- [ ] Gamification-Engine zur Motivation der Lernenden implementieren
+- [x] Gamification-Engine zur Motivation der Lernenden implementieren
 - [x] Skript `scripts/generate_badge_assets.sh` erzeugt Badge-Icons automatisch
 
 ### Milestone 2: Adaptive Learning Paths


### PR DESCRIPTION
## Summary
- implement `PointsManager`, `LevelManager`, and `BadgeManager` for basic gamification logic
- document badge generation script in gamification concept
- update roadmap, changelog, and next-step prompt for gamification milestone

## Testing
- `cd mrs-unkwn/backend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_689638104510832eaa41f30e3858adda