### PR TITLE
Implement adaptive learning path API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ dist/
 **/.env
 package-lock.json
 backend/data/
+backend/models/
 backend/src/integrations/*.json
 
 # Python

--- a/backend/package.json
+++ b/backend/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "ts-node --transpile-only tests/security.test.ts && ts-node --transpile-only tests/homework.test.ts && ts-node --transpile-only tests/organization.test.ts && ts-node --transpile-only tests/rateLimit.test.ts",
+    "test": "ts-node --transpile-only tests/security.test.ts && ts-node --transpile-only tests/homework.test.ts && ts-node --transpile-only tests/organization.test.ts && ts-node --transpile-only tests/rateLimit.test.ts && ts-node --transpile-only tests/adaptive.test.ts",
     "retrain-model": "ts-node --transpile-only ../scripts/retrain_homework_model.ts",
     "test:external": "ts-node --transpile-only tests/external_api.test.ts"
   },

--- a/backend/src/routes/adaptive.routes.ts
+++ b/backend/src/routes/adaptive.routes.ts
@@ -1,0 +1,17 @@
+import { Router } from 'express';
+import { AdaptivePathService } from '../services/adaptive';
+
+const router = Router();
+const service = new AdaptivePathService();
+
+router.post('/progress', async (req, res) => {
+  const { userId, pathId = 'default', nodeId, success } = req.body;
+  if (!userId || !nodeId || typeof success !== 'boolean') {
+    return res.status(400).json({ error: 'Invalid payload' });
+  }
+  await service.recordResult(userId, pathId, nodeId, success);
+  const next = await service.getNext(userId, pathId);
+  res.json({ next });
+});
+
+export default router;

--- a/backend/src/routes/index.ts
+++ b/backend/src/routes/index.ts
@@ -6,6 +6,7 @@ import schoolRoutes from './school.routes';
 import organizationRoutes from './organization.routes';
 import externalRoutes from './external.routes';
 import developerRoutes from './developer.routes';
+import adaptiveRoutes from './adaptive.routes';
 
 const router = Router();
 
@@ -16,5 +17,6 @@ router.use('/school', schoolRoutes);
 router.use('/organizations', organizationRoutes);
 router.use('/external', externalRoutes);
 router.use('/developer', developerRoutes);
+router.use('/adaptive', adaptiveRoutes);
 
 export default router;

--- a/backend/src/services/adaptive/learningPath.model.ts
+++ b/backend/src/services/adaptive/learningPath.model.ts
@@ -6,5 +6,5 @@ export interface LearningPathNode {
 
 export interface UserProgress {
   userId: string;
-  completed: Set<string>;
+  completed: { [pathId: string]: Set<string> };
 }

--- a/backend/tests/adaptive.test.ts
+++ b/backend/tests/adaptive.test.ts
@@ -1,0 +1,51 @@
+import { AdaptivePathService } from '../src/services/adaptive';
+import { AddressInfo } from 'net';
+
+async function run() {
+  const service = new AdaptivePathService();
+  let next = await service.getNext('user1');
+  if (!next || next.id !== 'intro') {
+    throw new Error('Expected intro as first node');
+  }
+  await service.recordResult('user1', 'default', 'intro', true);
+  next = await service.getNext('user1');
+  if (!next || next.id !== 'advanced') {
+    throw new Error('Expected advanced after intro');
+  }
+
+  process.env.DATABASE_URL = 'postgres://user:pass@localhost:5432/test';
+  process.env.JWT_SECRET = 'test-secret';
+  process.env.JWT_REFRESH_SECRET = 'test-refresh';
+  process.env.EMAIL_SERVICE_KEY = 'test-email';
+  process.env.NODE_ENV = 'test';
+
+  const { default: app } = await import('../src/index');
+  await new Promise<void>((resolve, reject) => {
+    const server = app.listen(0, async () => {
+      try {
+        const port = (server.address() as AddressInfo).port;
+        const res = await fetch(`http://localhost:${port}/api/adaptive/progress`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ userId: 'user2', nodeId: 'intro', success: true }),
+        });
+        const data = await res.json();
+        if (!data.next || data.next.id !== 'advanced') {
+          throw new Error('Expected advanced after posting progress');
+        }
+        server.close();
+        resolve();
+      } catch (err) {
+        server.close();
+        reject(err);
+      }
+    });
+  });
+
+  console.log('adaptive.test.ts passed');
+}
+
+run().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/codex/daten/adaptive_learning_paths.md
+++ b/codex/daten/adaptive_learning_paths.md
@@ -7,10 +7,14 @@
 - `LearningPathNode` Modell beschreibt einen Abschnitt des Lernpfads.
 - `AdaptivePathService` verwaltet Pfade, speichert Fortschritt und liefert den nächsten Abschnitt.
 
+## Aktueller Stand
+- Algorithmus berücksichtigt prerequisites und Nutzerfortschritt pro Pfad.
+- REST-Endpoint `POST /api/adaptive/progress` nimmt Ergebnisse entgegen und liefert den nächsten Abschnitt.
+
 ## Trainingsskript
 - [`scripts/train_adaptive_model.sh`](../../scripts/train_adaptive_model.sh) generiert das Modell automatisch.
 - Die erzeugten Dateien werden nicht versioniert und können bei Bedarf neu erstellt werden.
 
 ## Nächste Schritte
-- Algorithmus zur Berechnung der nächsten Lernschritte verfeinern.
-- REST-Endpunkte zur Fortschrittsübermittlung und Pfadabfrage implementieren.
+- Personalisierungslogik erweitern (Schwierigkeitsanpassung, Remediation).
+- Persistente Speicherung des Lernfortschritts hinzufügen.

--- a/codex/daten/changelog.md
+++ b/codex/daten/changelog.md
@@ -402,3 +402,10 @@
 - Konzeptdokument `adaptive_learning_paths.md` ergänzt
 - Skript `scripts/train_adaptive_model.sh` erzeugt Modellgewichte automatisch
 - Roadmap und Prompt aktualisiert
+
+### Phase 5: Adaptive Learning Paths Algorithm & API - 2025-08-11
+- Algorithmus zur Pfadberechnung basierend auf Nutzerfortschritt erweitert
+- REST-Route `POST /api/adaptive/progress` implementiert
+- Tests für Service und Route ergänzt und `package.json` aktualisiert
+- `scripts/train_adaptive_model.sh` erzeugt nun Platzhalter-Datensatz
+- Dokumentation, Roadmap und Prompt aktualisiert

--- a/codex/daten/prompt.md
+++ b/codex/daten/prompt.md
@@ -1,4 +1,4 @@
-# Nächster Schritt: Phase 5 Milestone 2 – Adaptive Learning Paths Algorithm & API
+# Nächster Schritt: Projektabschluss – Review & Feinschliff
 
 ## Status
 - Phase 0 abgeschlossen ✓
@@ -13,7 +13,7 @@
 - Phase 4 Milestone 3 abgeschlossen ✓
 - Phase 4 Milestone 4 abgeschlossen ✓
 - Phase 5 Milestone 1 abgeschlossen ✓
-- Phase 5 Milestone 2 in Arbeit ☐
+- Phase 5 Milestone 2 abgeschlossen ✓
 
 ## Referenzen
 - `/README.md`
@@ -25,20 +25,19 @@
 - `backend/third_party_api.md`
 
 ## Nächste Aufgabe
-Phase 5 Milestone 2 fortsetzen: Algorithmus zur dynamischen Lernpfad-Berechnung implementieren und Backend-Endpunkte für Fortschritt & Pfadabfrage anlegen.
+Gesamtes Projekt überprüfen, letzte Dokumentations- und Code-Checks durchführen.
 
 ### Vorbereitungen
 - Roadmap-Eintrag zu Phase 5 Milestone 2 prüfen.
 
 ### Implementierungsschritte
-- Logik entwickeln, die basierend auf Nutzerfortschritt den nächsten Lernabschnitt ermittelt.
-- REST-Route (z.B. `POST /api/adaptive/progress`) erstellen, die Ergebnis speichert und nächsten Abschnitt liefert.
-- `scripts/train_adaptive_model.sh` um Trainingsplatzhalter erweitern.
+- Dokumentation prüfen und ggf. korrigieren.
+- Offene Punkte oder TODOs identifizieren und abschließen.
 
 ### Validierung
-- Unit-Tests für AdaptivePathService und neue Route schreiben.
+- `npm test` im Backend ausführen.
 
 ### Selbstgenerierung
-- Nach Umsetzung Prompt aktualisieren.
+- Nach Abschluss finalen Prompt erstellen.
 
 *Hinweis: Codex kann keine Binärdateien mergen. Benötigte Dateien werden durch Skripte generiert. Halte den Codeumfang dieses Sprints unter 500 Zeilen.*

--- a/codex/daten/roadmap.md
+++ b/codex/daten/roadmap.md
@@ -375,5 +375,5 @@ Details: Endpoint liefert aktuelle Modellversion und letztes Trainingsdatum.
 - [x] Skript `scripts/generate_badge_assets.sh` erzeugt Badge-Icons automatisch
 
 ### Milestone 2: Adaptive Learning Paths
-- [ ] KI-gestützte Lernpfade basierend auf Nutzerleistung entwickeln
+- [x] KI-gestützte Lernpfade basierend auf Nutzerleistung entwickeln
 - [x] Skript `scripts/train_adaptive_model.sh` erstellt und trainiert notwendige Modelle

--- a/scripts/train_adaptive_model.sh
+++ b/scripts/train_adaptive_model.sh
@@ -6,8 +6,15 @@ set -e
 # Binary artifacts are not committed; they are produced on demand.
 
 ROOT_DIR="$(cd "$(dirname "$0")"/.. && pwd)"
+DATA_DIR="$ROOT_DIR/backend/data"
 MODEL_DIR="$ROOT_DIR/backend/models"
-mkdir -p "$MODEL_DIR"
+mkdir -p "$MODEL_DIR" "$DATA_DIR"
 
+# Generate placeholder dataset
+DATA_FILE="$DATA_DIR/adaptive_training.csv"
+echo "user_id,skill,score" > "$DATA_FILE"
+echo "u1,basics,0.9" >> "$DATA_FILE"
+
+# Produce dummy model weights
 echo "Simulated model weights" > "$MODEL_DIR/adaptive_model.bin"
-echo "Model trained and weights stored in $MODEL_DIR/adaptive_model.bin"
+echo "Model trained with $DATA_FILE and weights stored in $MODEL_DIR/adaptive_model.bin"


### PR DESCRIPTION
## Summary
- add adaptive learning path algorithm tracking progress per path
- expose POST /api/adaptive/progress endpoint and accompanying tests
- extend training script to generate placeholder dataset and ignore generated models

## Testing
- `bash scripts/train_adaptive_model.sh`
- `cd backend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_6896440244f8832e91cb7fd0564ac206