### PR TITLE
chore: log maintenance check and update prompt

### DIFF
--- a/codex/daten/changelog.md
+++ b/codex/daten/changelog.md
@@ -450,3 +450,7 @@
 ### Wartungscheck - 2025-08-11
 - Repository auf neue Issues geprüft
 - `npm test` (im `backend/`) und `pytest codex/tests` erneut ausgeführt – keine Fehler gefunden
+
+### Wartungscheck - 2025-08-12
+- Repository auf neue Issues geprüft
+- `npm test` (im `backend/`) und `pytest codex/tests` erneut ausgeführt – keine Fehler gefunden

--- a/codex/daten/prompt.md
+++ b/codex/daten/prompt.md
@@ -16,7 +16,7 @@
 - Phase 5 Milestone 2 abgeschlossen ✓
 - Phase 5 Milestone 3 abgeschlossen ✓
 
-- Letzter Wartungscheck am 2025-08-11 – keine offenen Issues
+- Letzter Wartungscheck am 2025-08-12 – keine offenen Issues
 
 ## Referenzen
 - `/README.md`
@@ -39,4 +39,4 @@ Projekt im Wartungsmodus halten, Fehlerberichte beobachten und bei Bedarf Bugfix
 ### Selbstgenerierung
 - Nach jeder Wartungsaufgabe neuen Prompt erstellen.
 
-*Hinweis: Codex kann keine Binärdateien mergen. Benötigte Dateien werden durch Skripte generiert. Halte den Codeumfang dieses Sprints unter 500 Zeilen.*
+*Hinweis: Codex kann keine Binärdateien mergen. Benötigte Dateien werden durch Skripte beim Ausführen automatisch erzeugt. Halte den Codeumfang dieses Sprints unter 500 Zeilen.*


### PR DESCRIPTION
## Summary
- document the latest maintenance review in the changelog
- refresh the prompt with the new check date and clarify that scripts must generate binary files when run

## Testing
- `npm test`
- `pytest codex/tests`


------
https://chatgpt.com/codex/tasks/task_e_68966fd38634832ea93e8af97841845e