### PR TITLE
chore: record maintenance check for 2025-09-01

### DIFF
--- a/codex/daten/changelog.md
+++ b/codex/daten/changelog.md
@@ -532,3 +532,8 @@
 - Repository auf neue Issues geprüft
 - `npm test` (im `backend/`) und `pytest codex/tests` ausgeführt – keine Fehler gefunden
 - Keine Binärdateien versioniert; notwendige Artefakte werden über Skripte erzeugt
+
+### Wartungscheck - 2025-09-01
+- Repository auf neue Issues geprüft
+- `npm test` (im `backend/`) und `pytest codex/tests` ausgeführt – keine Fehler gefunden
+- Keine Binärdateien versioniert; notwendige Artefakte werden über Skripte erzeugt

--- a/codex/daten/prompt.md
+++ b/codex/daten/prompt.md
@@ -16,7 +16,7 @@
 - Phase 5 Milestone 2 abgeschlossen ✓
 - Phase 5 Milestone 3 abgeschlossen ✓
 
- - Letzter Wartungscheck am 2025-08-31 – keine offenen Issues
+ - Letzter Wartungscheck am 2025-09-01 – keine offenen Issues
 
 ## Referenzen
 - `/README.md`

--- a/codex/daten/roadmap.md
+++ b/codex/daten/roadmap.md
@@ -402,3 +402,5 @@ Details: Endpoint liefert aktuelle Modellversion und letztes Trainingsdatum.
 - [x] Wartungscheck am 2025-08-28: Tests (`npm test`, `pytest codex/tests`) erfolgreich
 - [x] Wartungscheck am 2025-08-29: Tests (`npm test`, `pytest codex/tests`) erfolgreich
 - [x] Wartungscheck am 2025-08-30: Tests (`npm test`, `pytest codex/tests`) erfolgreich
+- [x] Wartungscheck am 2025-08-31: Tests (`npm test`, `pytest codex/tests`) erfolgreich
+- [x] Wartungscheck am 2025-09-01: Tests (`npm test`, `pytest codex/tests`) erfolgreich


### PR DESCRIPTION
## Summary
- log maintenance checks for August 31 and September 1 in roadmap
- document 2025-09-01 maintenance run in changelog and update prompt

## Testing
- `npm test`
- `pytest codex/tests`


------
https://chatgpt.com/codex/tasks/task_e_6896bf7d5bb0832e82f24ca9dab4f2f0