### PR TITLE
docs: add maintenance log for 2025-09-13

### DIFF
--- a/codex/daten/changelog.md
+++ b/codex/daten/changelog.md
@@ -585,3 +585,7 @@
 - Repository auf neue Issues geprüft
 - `npm test` (im `backend/`) und `pytest codex/tests` ausgeführt – keine Fehler gefunden
 - Keine Binärdateien versioniert; notwendige Artefakte werden über Skripte erzeugt
+### Wartungscheck - 2025-09-13
+- Repository auf neue Issues geprüft
+- `npm test` (im `backend/`) und `pytest codex/tests` ausgeführt – keine Fehler gefunden
+- Keine Binärdateien versioniert; notwendige Artefakte werden über Skripte erzeugt

--- a/codex/daten/prompt.md
+++ b/codex/daten/prompt.md
@@ -16,7 +16,7 @@
 - Phase 5 Milestone 2 abgeschlossen ✓
 - Phase 5 Milestone 3 abgeschlossen ✓
 
- - Letzter Wartungscheck am 2025-09-12 – keine offenen Issues
+ - Letzter Wartungscheck am 2025-09-13 – keine offenen Issues
 
 ## Referenzen
 - `/README.md`

--- a/codex/daten/roadmap.md
+++ b/codex/daten/roadmap.md
@@ -415,3 +415,4 @@ Details: Endpoint liefert aktuelle Modellversion und letztes Trainingsdatum.
 - [x] Wartungscheck am 2025-09-10: Tests (`npm test`, `pytest codex/tests`) erfolgreich
 - [x] Wartungscheck am 2025-09-11: Tests (`npm test`, `pytest codex/tests`) erfolgreich
 - [x] Wartungscheck am 2025-09-12: Tests (`npm test`, `pytest codex/tests`) erfolgreich
+- [x] Wartungscheck am 2025-09-13: Tests (`npm test`, `pytest codex/tests`) erfolgreich


### PR DESCRIPTION
## Summary
- log maintenance check for 2025-09-13 in roadmap and changelog
- update maintenance prompt with latest check date

## Testing
- `cd backend && npm test`
- `pytest codex/tests`


------
https://chatgpt.com/codex/tasks/task_e_6896ef4b5214832ea72f66dd4dea6596