### PR TITLE
Implement forgot password flow

### DIFF
--- a/codex/daten/changelog.md
+++ b/codex/daten/changelog.md
@@ -608,3 +608,9 @@
 - `HomePage` mit Logout-Button und Bestätigungsdialog ergänzt
 - Unit-Tests für Logout-Szenarien hinzugefügt
 - Roadmap und Prompt aktualisiert
+
+### Phase 1: Forgot Password Flow - 2025-09-14
+- `forgot_password_page.dart` mit Email-Formular erstellt
+- `AuthBloc` um `ForgotPasswordRequested` und `ResetPasswordRequested` Events erweitert
+- Repository-Methoden für `/api/auth/forgot-password` und `/api/auth/reset-password` implementiert
+- Routing, Tests und UI für Passwort-Zurücksetzen hinzugefügt

--- a/codex/daten/prompt.md
+++ b/codex/daten/prompt.md
@@ -1,10 +1,9 @@
-# Nächster Schritt: Forgot Password Flow
+# Nächster Schritt: Family Creation UI Screen
 
 ## Status
 - Phase 0 abgeschlossen ✓
-- Phase 1 Milestone 3: Auto-Login auf App-Start abgeschlossen ✓
-- Phase 1 Milestone 3: Logout Functionality abgeschlossen ✓
-- Phase 1 Milestone 3: Forgot Password Flow offen ✗
+- Phase 1 Milestone 3: Forgot Password Flow abgeschlossen ✓
+- Phase 1 Milestone 4: Family Creation UI Screen offen ✗
 
 ## Referenzen
 - `/README.md`
@@ -13,16 +12,15 @@
 - `/codex/daten/changelog.md`
 
 ## Nächste Aufgabe
-Forgot-Password-Flow implementieren.
+Family-Creation-UI implementieren.
 
 ### Vorbereitungen
 - `README.md` und Roadmap prüfen.
 
 ### Implementierungsschritte
-- `forgot_password_page.dart` mit Email-Input erstellen.
-- `ForgotPasswordRequested` Event und States im AuthBloc ergänzen.
-- Backend-API `/api/auth/forgot-password` ansprechen.
-- Erfolgs- und Fehlermeldungen darstellen.
+- `create_family_page.dart` mit Multi-Step-Wizard (Name, Regeln, Plan, Übersicht) erstellen.
+- Navigations-Buttons und Form-Validierung implementieren.
+- Erfolgs- und Fehlermeldungen anzeigen.
 
 ### Validierung
 - Entsprechende Tests (z. B. `npm test`, `pytest codex/tests`, `flutter test`) ausführen.

--- a/codex/daten/roadmap.md
+++ b/codex/daten/roadmap.md
@@ -137,7 +137,7 @@ Details: Erstelle `AppStartEvent` in AuthBloc. In Main-App-Widget, dispatch AppS
 [x] Logout Functionality:
 Details: Implementiere `LogoutRequested` Event-Handler in AuthBloc. Erstelle Logout-API-Call der Server-side-Token-Invalidation durchführt. Clear alle lokalen Storage-Data: Access-Token, Refresh-Token, User-Data, App-Settings. Reset alle BLoCs zu Initial-State. Navigate zurück zu Login-Screen. Zeige Confirmation-Dialog vor Logout-Action. Handle Network-Errors gracefully (Logout auch bei offline).
 
-[ ] Forgot Password Flow:
+[x] Forgot Password Flow:
 Details: Erstelle `forgot_password_page.dart` mit Email-Input-Field. Implementiere `ForgotPasswordRequested` Event und entsprechende States. Erstelle Backend-API-Call zu `/api/auth/forgot-password` endpoint. Zeige Success-Message mit "Email gesendet" Confirmation. Implementiere Password-Reset-Page für Deep-Link-Handling. Validate Reset-Token und ermögliche neues Password-Setzen. Update Password über API und auto-login.
 
 ### Milestone 4: Familie Management System

--- a/flutter_app/mrs_unkwn_app/lib/core/routing/app_router.dart
+++ b/flutter_app/mrs_unkwn_app/lib/core/routing/app_router.dart
@@ -6,6 +6,10 @@ import 'route_constants.dart';
 import '../../features/monitoring/presentation/pages/monitoring_dashboard_page.dart';
 import '../../features/analytics/presentation/pages/analytics_dashboard_page.dart';
 import '../../features/auth/presentation/pages/home_page.dart';
+import '../../features/auth/presentation/pages/login_page.dart';
+import '../../features/auth/presentation/pages/register_page.dart';
+import '../../features/auth/presentation/pages/forgot_password_page.dart';
+import '../../features/auth/presentation/pages/reset_password_page.dart';
 
 /// Central application router using [GoRouter].
 class AppRouter {
@@ -16,16 +20,26 @@ class AppRouter {
     routes: <GoRoute>[
       GoRoute(
         path: RouteConstants.login,
-        builder: (context, state) => const Placeholder(),
+        builder: (context, state) => const LoginPage(),
       ),
       GoRoute(
         path: RouteConstants.register,
-        builder: (context, state) => const Placeholder(),
+        builder: (context, state) => const RegisterPage(),
       ),
       GoRoute(
         path: RouteConstants.home,
         builder: (context, state) => const HomePage(),
         redirect: _authGuard,
+      ),
+      GoRoute(
+        path: RouteConstants.forgotPassword,
+        builder: (context, state) => const ForgotPasswordPage(),
+      ),
+      GoRoute(
+        path: RouteConstants.resetPassword,
+        builder: (context, state) => ResetPasswordPage(
+          token: state.uri.queryParameters['token'] ?? '',
+        ),
       ),
       GoRoute(
         path: RouteConstants.familySetup,

--- a/flutter_app/mrs_unkwn_app/lib/core/routing/route_constants.dart
+++ b/flutter_app/mrs_unkwn_app/lib/core/routing/route_constants.dart
@@ -5,4 +5,6 @@ class RouteConstants {
   static const String familySetup = '/family-setup';
   static const String monitoring = '/monitoring';
   static const String analytics = '/analytics';
+  static const String forgotPassword = '/forgot-password';
+  static const String resetPassword = '/reset-password';
 }

--- a/flutter_app/mrs_unkwn_app/lib/features/auth/presentation/pages/forgot_password_page.dart
+++ b/flutter_app/mrs_unkwn_app/lib/features/auth/presentation/pages/forgot_password_page.dart
@@ -1,0 +1,77 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+import '../bloc/auth_bloc.dart';
+
+class ForgotPasswordPage extends StatefulWidget {
+  const ForgotPasswordPage({super.key});
+
+  @override
+  State<ForgotPasswordPage> createState() => _ForgotPasswordPageState();
+}
+
+class _ForgotPasswordPageState extends State<ForgotPasswordPage> {
+  final _formKey = GlobalKey<FormState>();
+  final _emailController = TextEditingController();
+
+  @override
+  void dispose() {
+    _emailController.dispose();
+    super.dispose();
+  }
+
+  void _submit() {
+    if (_formKey.currentState?.validate() ?? false) {
+      context.read<AuthBloc>().add(ForgotPasswordRequested(_emailController.text));
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocListener<AuthBloc, AuthState>(
+      listener: (context, state) {
+        if (state is ForgotPasswordEmailSent) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            const SnackBar(content: Text('Email gesendet')),
+          );
+        } else if (state is AuthFailure) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(content: Text(state.message)),
+          );
+        }
+      },
+      child: Scaffold(
+        appBar: AppBar(title: const Text('Passwort vergessen')),
+        body: Padding(
+          padding: const EdgeInsets.all(16),
+          child: Form(
+            key: _formKey,
+            child: Column(
+              children: [
+                TextFormField(
+                  controller: _emailController,
+                  decoration: const InputDecoration(labelText: 'Email'),
+                  validator: (value) {
+                    if (value == null || value.isEmpty) {
+                      return 'Bitte Email eingeben';
+                    }
+                    final emailRegex = RegExp(r'^[\\w\\.-]+@[\\w\\.-]+\\.[a-zA-Z]{2,4}\$');
+                    if (!emailRegex.hasMatch(value)) {
+                      return 'Ungültiges Email-Format';
+                    }
+                    return null;
+                  },
+                ),
+                const SizedBox(height: 24),
+                ElevatedButton(
+                  onPressed: _submit,
+                  child: const Text('Zurücksetzen'),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/flutter_app/mrs_unkwn_app/lib/features/auth/presentation/pages/login_page.dart
+++ b/flutter_app/mrs_unkwn_app/lib/features/auth/presentation/pages/login_page.dart
@@ -146,6 +146,10 @@ class _LoginPageState extends State<LoginPage> {
                     onPressed: () {},
                     child: const Text('Registrieren'),
                   ),
+                  TextButton(
+                    onPressed: () => context.go(RouteConstants.forgotPassword),
+                    child: const Text('Passwort vergessen?'),
+                  ),
                 ],
               ),
             ),

--- a/flutter_app/mrs_unkwn_app/lib/features/auth/presentation/pages/reset_password_page.dart
+++ b/flutter_app/mrs_unkwn_app/lib/features/auth/presentation/pages/reset_password_page.dart
@@ -1,0 +1,84 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+import '../bloc/auth_bloc.dart';
+import '../../../../core/routing/route_constants.dart';
+import 'package:go_router/go_router.dart';
+
+class ResetPasswordPage extends StatefulWidget {
+  const ResetPasswordPage({super.key, required this.token});
+
+  final String token;
+
+  @override
+  State<ResetPasswordPage> createState() => _ResetPasswordPageState();
+}
+
+class _ResetPasswordPageState extends State<ResetPasswordPage> {
+  final _formKey = GlobalKey<FormState>();
+  final _passwordController = TextEditingController();
+
+  @override
+  void dispose() {
+    _passwordController.dispose();
+    super.dispose();
+  }
+
+  void _submit() {
+    if (_formKey.currentState?.validate() ?? false) {
+      context.read<AuthBloc>().add(
+            ResetPasswordRequested(widget.token, _passwordController.text),
+          );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocListener<AuthBloc, AuthState>(
+      listener: (context, state) {
+        if (state is AuthSuccess) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            const SnackBar(content: Text('Passwort aktualisiert')),
+          );
+          context.go(RouteConstants.home);
+        } else if (state is AuthFailure) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(content: Text(state.message)),
+          );
+        }
+      },
+      child: Scaffold(
+        appBar: AppBar(title: const Text('Neues Passwort setzen')),
+        body: Padding(
+          padding: const EdgeInsets.all(16),
+          child: Form(
+            key: _formKey,
+            child: Column(
+              children: [
+                TextFormField(
+                  controller: _passwordController,
+                  decoration: const InputDecoration(labelText: 'Neues Passwort'),
+                  obscureText: true,
+                  validator: (value) {
+                    if (value == null || value.isEmpty) {
+                      return 'Bitte Passwort eingeben';
+                    }
+                    if (value.length < 6) {
+                      return 'Mindestens 6 Zeichen';
+                    }
+                    return null;
+                  },
+                ),
+                const SizedBox(height: 24),
+                ElevatedButton(
+                  onPressed: _submit,
+                  child: const Text('Speichern'),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/flutter_app/mrs_unkwn_app/test/unit/auth/auth_bloc_test.dart
+++ b/flutter_app/mrs_unkwn_app/test/unit/auth/auth_bloc_test.dart
@@ -77,4 +77,27 @@ void main() {
     act: (bloc) => bloc.add(LogoutRequested()),
     expect: () => [isA<AuthLoading>(), isA<AuthInitial>()],
   );
+
+  blocTest<AuthBloc, AuthState>(
+    'emits [AuthLoading, ForgotPasswordEmailSent] on forgot password',
+    build: () {
+      when(() => repository.forgotPassword(any()))
+          .thenAnswer((_) async {});
+      return AuthBloc(repository);
+    },
+    act: (bloc) => bloc.add(ForgotPasswordRequested('a@b.com')),
+    expect: () => [isA<AuthLoading>(), isA<ForgotPasswordEmailSent>()],
+  );
+
+  blocTest<AuthBloc, AuthState>(
+    'emits [AuthLoading, AuthSuccess] on reset password',
+    build: () {
+      when(() => repository.resetPassword(any(), any()))
+          .thenAnswer((_) async => const User(id: '1'));
+      return AuthBloc(repository);
+    },
+    act: (bloc) =>
+        bloc.add(ResetPasswordRequested('token', 'newPass123')),
+    expect: () => [isA<AuthLoading>(), isA<AuthSuccess>()],
+  );
 }


### PR DESCRIPTION
## Summary
- add forgot and reset password pages with routing
- extend auth bloc and repository for password reset
- mark roadmap milestone and update prompt

## Testing
- `npm test --prefix backend`
- `pytest codex/tests`
- `flutter test flutter_app/mrs_unkwn_app` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68970778aa10832eb9817a26f5ae3e17