### PR TITLE
feat: add family data models

### DIFF
--- a/codex/daten/changelog.md
+++ b/codex/daten/changelog.md
@@ -619,3 +619,8 @@
 - `create_family_page.dart` mit Multi-Step-Wizard erstellt
 - Routing über `AppRouter` angebunden und `FamilyRepository` im Service Locator registriert
 - Roadmap und Prompt aktualisiert
+
+### Phase 1: Family Model und Data Classes - 2025-09-14
+- `Family` und `FamilyMember` Modelle mit `@JsonSerializable` implementiert
+- Enums `FamilyRole` und `SubscriptionTier` hinzugefügt
+- Roadmap und Prompt aktualisiert

--- a/codex/daten/prompt.md
+++ b/codex/daten/prompt.md
@@ -1,9 +1,10 @@
-# Nächster Schritt: Family Model und Data Classes
+# Nächster Schritt: Family Repository Implementation
 
 ## Status
 - Phase 0 abgeschlossen ✓
 - Phase 1 Milestone 4: Family Creation UI Screen abgeschlossen ✓
-- Phase 1 Milestone 4: Family Model und Data Classes offen ✗
+- Phase 1 Milestone 4: Family Model und Data Classes abgeschlossen ✓
+- Phase 1 Milestone 4: Family Repository Implementation offen ✗
 
 ## Referenzen
 - `/README.md`
@@ -12,15 +13,18 @@
 - `/codex/daten/changelog.md`
 
 ## Nächste Aufgabe
-Family- und FamilyMember-Modelklassen erstellen.
+Family Repository für API-Aufrufe implementieren.
 
 ### Vorbereitungen
 - `README.md` und Roadmap prüfen.
 
 ### Implementierungsschritte
-- Datei `lib/features/family/data/models/family.dart` mit `Family` und `FamilyMember` Klassen erstellen.
-- `@JsonSerializable()` verwenden und `fromJson`/`toJson` implementieren.
-- Enums für `FamilyRole` und `SubscriptionTier` definieren.
+- Datei `lib/features/family/data/repositories/family_repository_impl.dart` erstellen.
+- `createFamily(CreateFamilyRequest)` mit POST-API-Call implementieren.
+- `getFamily(String familyId)` mit GET-API-Call implementieren.
+- `updateFamily(String familyId, UpdateFamilyRequest)` mit PUT-API-Call implementieren.
+- `deleteFamily(String familyId)` mit DELETE-API-Call implementieren.
+- HTTP- und Netzwerkfehler angemessen behandeln.
 
 ### Validierung
 - Entsprechende Tests (z. B. `npm test`, `pytest codex/tests`, `flutter test`) ausführen.

--- a/codex/daten/roadmap.md
+++ b/codex/daten/roadmap.md
@@ -145,7 +145,7 @@ Details: Erstelle `forgot_password_page.dart` mit Email-Input-Field. Implementie
 [x] Family Creation UI Screen:
 Details: Erstelle `lib/features/family/presentation/pages/create_family_page.dart`. Implementiere Multi-Step-Wizard mit `PageView` und Step-Indicator. Step 1: Family-Name-Input mit Validation. Step 2: Family-Rules-Setup (Study-Hours, Bedtime, etc.). Step 3: Subscription-Plan-Selection mit Pricing-Cards. Step 4: Summary und Confirmation. Implementiere Navigation-Buttons (Next/Previous) mit Form-Validation vor Next-Step.
 
-[ ] Family Model und Data Classes:
+[x] Family Model und Data Classes:
 Details: Erstelle `lib/features/family/data/models/family.dart`. Implementiere `Family` Model-Klasse mit `@JsonSerializable()` Annotation. Properties: `id`, `name`, `createdBy`, `subscriptionTier`, `settings`, `createdAt`, `updatedAt`. Erstelle `FamilyMember` Model mit `userId`, `role`, `permissions`, `joinedAt`. Implementiere `fromJson()` und `toJson()` Methoden. Definiere Enums für `FamilyRole` und `SubscriptionTier`.
 
 [ ] Family Repository Implementation:

--- a/flutter_app/mrs_unkwn_app/lib/features/family/data/models/family.dart
+++ b/flutter_app/mrs_unkwn_app/lib/features/family/data/models/family.dart
@@ -1,0 +1,56 @@
+import 'package:json_annotation/json_annotation.dart';
+
+part 'family.g.dart';
+
+enum FamilyRole { parent, child, guardian, admin }
+
+enum SubscriptionTier { basic, family, premium }
+
+@JsonSerializable(explicitToJson: true)
+class FamilyMember {
+  final String userId;
+  final FamilyRole role;
+  final List<String>? permissions;
+  final DateTime joinedAt;
+
+  const FamilyMember({
+    required this.userId,
+    required this.role,
+    this.permissions,
+    required this.joinedAt,
+  });
+
+  factory FamilyMember.fromJson(Map<String, dynamic> json) =>
+      _$FamilyMemberFromJson(json);
+
+  Map<String, dynamic> toJson() => _$FamilyMemberToJson(this);
+}
+
+@JsonSerializable(explicitToJson: true)
+class Family {
+  final String id;
+  final String name;
+  final String createdBy;
+  final SubscriptionTier subscriptionTier;
+  final Map<String, dynamic>? settings;
+  final DateTime createdAt;
+  final DateTime updatedAt;
+  final List<FamilyMember>? members;
+
+  const Family({
+    required this.id,
+    required this.name,
+    required this.createdBy,
+    required this.subscriptionTier,
+    this.settings,
+    required this.createdAt,
+    required this.updatedAt,
+    this.members,
+  });
+
+  factory Family.fromJson(Map<String, dynamic> json) =>
+      _$FamilyFromJson(json);
+
+  Map<String, dynamic> toJson() => _$FamilyToJson(this);
+}
+

--- a/flutter_app/mrs_unkwn_app/lib/features/family/data/models/family.g.dart
+++ b/flutter_app/mrs_unkwn_app/lib/features/family/data/models/family.g.dart
@@ -1,0 +1,55 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'family.dart';
+
+FamilyMember _$FamilyMemberFromJson(Map<String, dynamic> json) => FamilyMember(
+      userId: json['userId'] as String,
+      role: $enumDecode(_$FamilyRoleEnumMap, json['role']),
+      permissions: (json['permissions'] as List<dynamic>?)?.map((e) => e as String).toList(),
+      joinedAt: DateTime.parse(json['joinedAt'] as String),
+    );
+
+Map<String, dynamic> _$FamilyMemberToJson(FamilyMember instance) => <String, dynamic>{
+      'userId': instance.userId,
+      'role': _$FamilyRoleEnumMap[instance.role]!,
+      'permissions': instance.permissions,
+      'joinedAt': instance.joinedAt.toIso8601String(),
+    };
+
+Family _$FamilyFromJson(Map<String, dynamic> json) => Family(
+      id: json['id'] as String,
+      name: json['name'] as String,
+      createdBy: json['createdBy'] as String,
+      subscriptionTier: $enumDecode(_$SubscriptionTierEnumMap, json['subscriptionTier']),
+      settings: json['settings'] as Map<String, dynamic>?,
+      createdAt: DateTime.parse(json['createdAt'] as String),
+      updatedAt: DateTime.parse(json['updatedAt'] as String),
+      members: (json['members'] as List<dynamic>?)
+          ?.map((e) => FamilyMember.fromJson(e as Map<String, dynamic>))
+          .toList(),
+    );
+
+Map<String, dynamic> _$FamilyToJson(Family instance) => <String, dynamic>{
+      'id': instance.id,
+      'name': instance.name,
+      'createdBy': instance.createdBy,
+      'subscriptionTier': _$SubscriptionTierEnumMap[instance.subscriptionTier]!,
+      'settings': instance.settings,
+      'createdAt': instance.createdAt.toIso8601String(),
+      'updatedAt': instance.updatedAt.toIso8601String(),
+      'members': instance.members?.map((e) => e.toJson()).toList(),
+    };
+
+const Map<FamilyRole, String> _$FamilyRoleEnumMap = {
+  FamilyRole.parent: 'parent',
+  FamilyRole.child: 'child',
+  FamilyRole.guardian: 'guardian',
+  FamilyRole.admin: 'admin',
+};
+
+const Map<SubscriptionTier, String> _$SubscriptionTierEnumMap = {
+  SubscriptionTier.basic: 'basic',
+  SubscriptionTier.family: 'family',
+  SubscriptionTier.premium: 'premium',
+};
+


### PR DESCRIPTION
## Summary
- add `Family` and `FamilyMember` models with enums and JSON serialization
- mark family model task complete in roadmap and changelog
- update prompt for upcoming family repository implementation

## Testing
- `npm test`
- `pytest codex/tests`
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68970f721ce0832eadf6888a11f69902