### PR TITLE
feat: add QR code invitations

### DIFF
--- a/codex/daten/changelog.md
+++ b/codex/daten/changelog.md
@@ -642,3 +642,9 @@
 - `FamilyRepository` und Backend-Routen für `/api/family/invite` und `/invite/accept` implementiert
 - Einladungs-Tokens mit 24h-Gültigkeit generiert und Annahme-Flow ergänzt
 - Roadmap und Prompt aktualisiert
+
+### Phase 1: QR Code Invitation Feature - 2025-09-14
+- Dependencies `qr_flutter` und `qr_code_scanner` hinzugefügt
+- QR-Code-Generierung im Einladungsscreen implementiert
+- QR-Scanner-Seite zur automatischen Einladungsannahme erstellt
+- Roadmap und Prompt aktualisiert

--- a/codex/daten/prompt.md
+++ b/codex/daten/prompt.md
@@ -1,4 +1,4 @@
-# Nächster Schritt: QR Code Invitation Feature
+# Nächster Schritt: Family Settings Management
 
 ## Status
 - Phase 0 abgeschlossen ✓
@@ -7,7 +7,8 @@
 - Phase 1 Milestone 4: Family Repository Implementation abgeschlossen ✓
 - Phase 1 Milestone 4: Family BLoC State Management abgeschlossen ✓
 - Phase 1 Milestone 4: Family Member Invitation System abgeschlossen ✓
-- Phase 1 Milestone 4: QR Code Invitation Feature offen ✗
+- Phase 1 Milestone 4: QR Code Invitation Feature abgeschlossen ✓
+- Phase 1 Milestone 4: Family Settings Management offen ✗
 
 ## Referenzen
 - `/README.md`
@@ -16,17 +17,17 @@
 - `/codex/daten/changelog.md`
 
 ## Nächste Aufgabe
-QR-Code-Einladungsfunktion implementieren.
+Familien-Einstellungen-Verwaltung implementieren.
 
 ### Vorbereitungen
 - `README.md` und Roadmap prüfen.
 
 ### Implementierungsschritte
-- Dependencies `qr_flutter` und `qr_code_scanner` hinzufügen.
-- QR-Code im Invite-Member-Screen erzeugen, der den Einladungstoken enthält.
-- QR-Scanner-Screen für Einladungsannahme implementieren.
-- Kamera-Berechtigungen und Scanner-Fehler behandeln.
-- Gescannten QR-Code validieren und Einladung automatisch verarbeiten.
+- `family_settings_page.dart` mit Kategorien (Study-Rules, Screen-Time-Limits, Bedtime-Schedule, App-Restrictions) erstellen.
+- Toggle-Switches, Sliders und Time-Picker für verschiedene Settings einbauen.
+- `FamilySettings` Model-Klasse mit Serialization implementieren.
+- Settings-Update-API-Calls mit Optimistic-Updates umsetzen.
+- Settings-Vererbung zwischen Family-Level und Member-Level behandeln.
 
 ### Validierung
 - Entsprechende Tests (z. B. `npm test`, `pytest codex/tests`, `flutter test`) ausführen.

--- a/codex/daten/roadmap.md
+++ b/codex/daten/roadmap.md
@@ -157,7 +157,7 @@ Details: Erstelle `family_bloc.dart` mit Events: `CreateFamilyRequested`, `LoadF
 [x] Family Member Invitation System:
 Details: Erstelle `invite_member_page.dart` mit Email-Input und Role-Selection. Implementiere `InviteMemberRequested` Event in FamilyBloc. Erstelle Backend-API für `/api/family/invite` endpoint. Generate Invitation-Token mit Expiry-Date (24h). Send Invitation-Email mit Deep-Link zur App. Implementiere Invitation-Acceptance-Flow mit Token-Validation. Update Family-Members-List nach successful Invitation-Acceptance.
 
-[ ] QR Code Invitation Feature:
+[x] QR Code Invitation Feature:
 Details: Füge `qr_flutter: ^4.1.0` und `qr_code_scanner: ^1.0.1` zu Dependencies hinzu. Erstelle QR-Code-Generation-Feature in Invite-Member-Screen. QR-Code enthält Invitation-Token und Family-Information. Implementiere QR-Scanner-Screen für Invitation-Acceptance. Handle Camera-Permissions und Scanner-Errors. Validate gescannten QR-Code und process Invitation automatisch.
 
 [ ] Family Settings Management:

--- a/flutter_app/mrs_unkwn_app/lib/features/family/data/repositories/family_repository.dart
+++ b/flutter_app/mrs_unkwn_app/lib/features/family/data/repositories/family_repository.dart
@@ -17,8 +17,8 @@ abstract class FamilyRepository {
   /// Deletes the family with [familyId].
   Future<void> deleteFamily(String familyId);
 
-  /// Sends an invitation to join a family.
-  Future<void> inviteMember(InviteMemberRequest request);
+  /// Sends an invitation to join a family and returns the invitation token.
+  Future<String> inviteMember(InviteMemberRequest request);
 
   /// Accepts an invitation token and returns the updated family.
   Future<Family> acceptInvitation(String token);

--- a/flutter_app/mrs_unkwn_app/lib/features/family/data/repositories/family_repository_impl.dart
+++ b/flutter_app/mrs_unkwn_app/lib/features/family/data/repositories/family_repository_impl.dart
@@ -77,14 +77,19 @@ class FamilyRepositoryImpl implements FamilyRepository {
     }
   }
 
-  /// Sends an invitation to join a family.
+  /// Sends an invitation to join a family and returns the invitation token.
   @override
-  Future<void> inviteMember(InviteMemberRequest request) async {
+  Future<String> inviteMember(InviteMemberRequest request) async {
     try {
-      await _dio.post<void>(
+      final response = await _dio.post<Map<String, dynamic>>(
         '/api/family/invite',
         data: request.toJson(),
       );
+      final token = response.data?['data']?['token'] as String?;
+      if (token == null) {
+        throw Exception('Invalid response format');
+      }
+      return token;
     } catch (e) {
       throw Exception('Invite member failed: $e');
     }

--- a/flutter_app/mrs_unkwn_app/lib/features/family/presentation/bloc/family_bloc.dart
+++ b/flutter_app/mrs_unkwn_app/lib/features/family/presentation/bloc/family_bloc.dart
@@ -112,8 +112,8 @@ class FamilyBloc extends BaseBloc<FamilyEvent, FamilyState> {
   ) async {
     emit(const FamilyLoading());
     try {
-      await _repository.inviteMember(event.request);
-      emit(const FamilyInvitationSent());
+      final token = await _repository.inviteMember(event.request);
+      emit(FamilyInvitationSent(token));
     } catch (e) {
       emit(FamilyError(e.toString()));
     }

--- a/flutter_app/mrs_unkwn_app/lib/features/family/presentation/bloc/family_state.dart
+++ b/flutter_app/mrs_unkwn_app/lib/features/family/presentation/bloc/family_state.dart
@@ -40,7 +40,13 @@ class FamilyCreated extends FamilyState {
 
 /// State emitted after an invitation was sent.
 class FamilyInvitationSent extends FamilyState {
-  const FamilyInvitationSent();
+  const FamilyInvitationSent(this.token);
+
+  /// Invitation token to be shared, e.g., via QR code.
+  final String token;
+
+  @override
+  List<Object?> get props => [token];
 }
 
 /// Error state with message.

--- a/flutter_app/mrs_unkwn_app/lib/features/family/presentation/pages/invite_member_page.dart
+++ b/flutter_app/mrs_unkwn_app/lib/features/family/presentation/pages/invite_member_page.dart
@@ -1,11 +1,13 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:qr_flutter/qr_flutter.dart';
 
 import '../../../../core/di/service_locator.dart';
 import '../../data/models/family.dart';
 import '../../data/models/invite_member_request.dart';
 import '../../data/repositories/family_repository.dart';
 import '../bloc/family_bloc.dart';
+import 'qr_invitation_scanner_page.dart';
 
 /// Page for inviting a new member to the family.
 class InviteMemberPage extends StatefulWidget {
@@ -40,12 +42,45 @@ class _InviteMemberPageState extends State<InviteMemberPage> {
     return BlocProvider(
       create: (_) => FamilyBloc(sl<FamilyRepository>()),
       child: Scaffold(
-        appBar: AppBar(title: const Text('Mitglied einladen')),
+        appBar: AppBar(
+          title: const Text('Mitglied einladen'),
+          actions: [
+            IconButton(
+              icon: const Icon(Icons.qr_code_scanner),
+              onPressed: () async {
+                final token = await Navigator.of(context).push<String>(
+                  MaterialPageRoute(
+                    builder: (_) => BlocProvider.value(
+                      value: context.read<FamilyBloc>(),
+                      child: const QrInvitationScannerPage(),
+                    ),
+                  ),
+                );
+                if (token != null) {
+                  context
+                      .read<FamilyBloc>()
+                      .add(AcceptInvitationRequested(token));
+                }
+              },
+            ),
+          ],
+        ),
         body: BlocConsumer<FamilyBloc, FamilyState>(
           listener: (context, state) {
             if (state is FamilyInvitationSent) {
+              showDialog(
+                context: context,
+                builder: (_) => AlertDialog(
+                  title: const Text('QR-Code Einladung'),
+                  content: QrImageView(
+                    data: state.token,
+                    size: 200,
+                  ),
+                ),
+              );
+            } else if (state is FamilyLoaded) {
               ScaffoldMessenger.of(context).showSnackBar(
-                const SnackBar(content: Text('Einladung gesendet')),
+                const SnackBar(content: Text('Einladung angenommen')),
               );
             } else if (state is FamilyError) {
               ScaffoldMessenger.of(context).showSnackBar(

--- a/flutter_app/mrs_unkwn_app/lib/features/family/presentation/pages/qr_invitation_scanner_page.dart
+++ b/flutter_app/mrs_unkwn_app/lib/features/family/presentation/pages/qr_invitation_scanner_page.dart
@@ -1,0 +1,57 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:qr_code_scanner/qr_code_scanner.dart';
+
+import '../bloc/family_bloc.dart';
+
+/// Page to scan a QR code and accept a family invitation.
+class QrInvitationScannerPage extends StatefulWidget {
+  const QrInvitationScannerPage({super.key});
+
+  @override
+  State<QrInvitationScannerPage> createState() => _QrInvitationScannerPageState();
+}
+
+class _QrInvitationScannerPageState extends State<QrInvitationScannerPage> {
+  final GlobalKey qrKey = GlobalKey(debugLabel: 'QR');
+  QRViewController? controller;
+
+  @override
+  void dispose() {
+    controller?.dispose();
+    super.dispose();
+  }
+
+  void _onQRViewCreated(QRViewController ctrl) {
+    controller = ctrl;
+    ctrl.scannedDataStream.listen((scanData) {
+      final code = scanData.code;
+      if (code != null) {
+        ctrl.pauseCamera();
+        context.read<FamilyBloc>().add(AcceptInvitationRequested(code));
+        Navigator.of(context).pop(code);
+      }
+    });
+  }
+
+  void _onPermissionSet(BuildContext context, QRViewController ctrl, bool granted) {
+    if (!granted) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Kamerazugriff verweigert')),
+      );
+      Navigator.of(context).pop();
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('QR-Code scannen')),
+      body: QRView(
+        key: qrKey,
+        onQRViewCreated: _onQRViewCreated,
+        onPermissionSet: (ctrl, p) => _onPermissionSet(context, ctrl, p),
+      ),
+    );
+  }
+}

--- a/flutter_app/mrs_unkwn_app/pubspec.yaml
+++ b/flutter_app/mrs_unkwn_app/pubspec.yaml
@@ -18,6 +18,8 @@ dependencies:
   hive: ^2.2.3
   json_annotation: ^4.8.1
   equatable: ^2.0.5
+  qr_flutter: ^4.1.0
+  qr_code_scanner: ^1.0.1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- add QR code dependencies and invitation scanner
- return invitation token for family invites
- show QR code in invite page and accept via scanner

## Testing
- `npm test`
- `pytest codex/tests`
- `flutter pub get` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6897235798fc832e85889c255cc3310f