### PR TITLE
feat: add device monitoring platform channel

### DIFF
--- a/codex/daten/changelog.md
+++ b/codex/daten/changelog.md
@@ -683,3 +683,7 @@
 - `FamilyService` mit WebSocket-Verbindung und Hive-Caching implementiert
 - `family_dashboard_page.dart` zeigt Sync-Status an und lädt Updates automatisch
 - `service_locator.dart`, `family_bloc.dart` und `pubspec.yaml` entsprechend erweitert
+
+### Phase 1: Platform Channel Setup für Device Monitoring - 2025-09-16
+- `device_monitoring.dart` mit MethodChannel und Mock-Implementierung angelegt
+- Roadmap und Prompt aktualisiert

--- a/codex/daten/prompt.md
+++ b/codex/daten/prompt.md
@@ -1,4 +1,4 @@
-# Nächster Schritt: Platform Channel Setup für Device Monitoring
+# Nächster Schritt: Android Native Code für App Usage Tracking
 
 ## Status
 - Phase 0 abgeschlossen ✓
@@ -14,7 +14,8 @@
 - Phase 1 Milestone 4: Family Role-Based Permissions abgeschlossen ✓
 - Phase 1 Milestone 4: Family Subscription Management abgeschlossen ✓
 - Phase 1 Milestone 4: Family Data Synchronization abgeschlossen ✓
-- Phase 1 Milestone 5: Platform Channel Setup für Device Monitoring offen ✗
+- Phase 1 Milestone 5: Platform Channel Setup für Device Monitoring abgeschlossen ✓
+- Phase 1 Milestone 5: Android Native Code für App Usage Tracking offen ✗
 
 ## Referenzen
 - `/README.md`
@@ -23,15 +24,15 @@
 - `/codex/daten/changelog.md`
 
 ## Nächste Aufgabe
-Platform Channel Setup für Device Monitoring implementieren.
+Android Native Code für App Usage Tracking implementieren.
 
 ### Vorbereitungen
 - `README.md` und Roadmap prüfen.
 
 ### Implementierungsschritte
-- `platform_channels/device_monitoring.dart` mit MethodChannel `com.mrsunkwn/device_monitoring` anlegen.
-- Methoden `startMonitoring()`, `stopMonitoring()`, `getAppUsageStats()` und `getInstalledApps()` definieren.
-- Plattform-spezifische Fehler abfangen und Mock-Implementierung für Tests bereitstellen.
+- `android/app/src/main/kotlin/DeviceMonitoringPlugin.kt` erstellen.
+- `PACKAGE_USAGE_STATS` Berechtigung anfordern und `UsageStatsManager` nutzen.
+- JSON-formatierte Nutzungsdaten an Flutter zurückgeben und Fehlerfälle behandeln.
 
 ### Validierung
 - Entsprechende Tests (z. B. `npm test`, `pytest codex/tests`, `flutter test`) ausführen.

--- a/codex/daten/roadmap.md
+++ b/codex/daten/roadmap.md
@@ -180,7 +180,7 @@ Details: Implementiert Real-time-Data-Sync für Family-Updates via WebSocket-Ver
 
 ### Milestone 5: Basic Device Monitoring Foundation
 
-[ ] Platform Channel Setup für Device Monitoring:
+[x] Platform Channel Setup für Device Monitoring:
 Details: Erstelle `platform_channels/device_monitoring.dart`. Definiere `MethodChannel('com.mrsunkwn/device_monitoring')`. Implementiere Flutter-Methods: `startMonitoring()`, `stopMonitoring()`, `getAppUsageStats()`, `getInstalledApps()`. Handle Platform-specific-Errors und Missing-Method-Implementations. Erstelle Mock-Implementation für Development-Testing ohne native Code.
 
 [ ] Android Native Code für App Usage Tracking:

--- a/flutter_app/mrs_unkwn_app/lib/platform_channels/device_monitoring.dart
+++ b/flutter_app/mrs_unkwn_app/lib/platform_channels/device_monitoring.dart
@@ -1,0 +1,102 @@
+import 'package:flutter/services.dart';
+
+import '../core/utils/logger.dart';
+
+/// Provides an interface to native device monitoring features via
+/// a [MethodChannel].
+abstract class DeviceMonitoring {
+  /// Starts background monitoring on the native platform.
+  Future<void> startMonitoring();
+
+  /// Stops background monitoring on the native platform.
+  Future<void> stopMonitoring();
+
+  /// Returns application usage statistics from the native platform.
+  Future<List<Map<String, dynamic>>> getAppUsageStats();
+
+  /// Returns a list of installed applications from the native platform.
+  Future<List<Map<String, dynamic>>> getInstalledApps();
+}
+
+/// Default implementation of [DeviceMonitoring] using a
+/// `MethodChannel` with name `com.mrsunkwn/device_monitoring`.
+class MethodChannelDeviceMonitoring implements DeviceMonitoring {
+  const MethodChannelDeviceMonitoring();
+
+  static const MethodChannel _channel =
+      MethodChannel('com.mrsunkwn/device_monitoring');
+
+  @override
+  Future<void> startMonitoring() async {
+    try {
+      await _channel.invokeMethod('startMonitoring');
+    } on PlatformException catch (e, stack) {
+      Logger.error('startMonitoring failed: ${e.message}', e, stack);
+    } on MissingPluginException {
+      Logger.warning('startMonitoring not implemented on this platform');
+    }
+  }
+
+  @override
+  Future<void> stopMonitoring() async {
+    try {
+      await _channel.invokeMethod('stopMonitoring');
+    } on PlatformException catch (e, stack) {
+      Logger.error('stopMonitoring failed: ${e.message}', e, stack);
+    } on MissingPluginException {
+      Logger.warning('stopMonitoring not implemented on this platform');
+    }
+  }
+
+  @override
+  Future<List<Map<String, dynamic>>> getAppUsageStats() async {
+    try {
+      final result =
+          await _channel.invokeMethod<List<dynamic>>('getAppUsageStats');
+      return (result ?? <dynamic>[])
+          .cast<Map<dynamic, dynamic>>()
+          .map((e) => e.cast<String, dynamic>())
+          .toList();
+    } on PlatformException catch (e, stack) {
+      Logger.error('getAppUsageStats failed: ${e.message}', e, stack);
+      return [];
+    } on MissingPluginException {
+      Logger.warning('getAppUsageStats not implemented on this platform');
+      return [];
+    }
+  }
+
+  @override
+  Future<List<Map<String, dynamic>>> getInstalledApps() async {
+    try {
+      final result =
+          await _channel.invokeMethod<List<dynamic>>('getInstalledApps');
+      return (result ?? <dynamic>[])
+          .cast<Map<dynamic, dynamic>>()
+          .map((e) => e.cast<String, dynamic>())
+          .toList();
+    } on PlatformException catch (e, stack) {
+      Logger.error('getInstalledApps failed: ${e.message}', e, stack);
+      return [];
+    } on MissingPluginException {
+      Logger.warning('getInstalledApps not implemented on this platform');
+      return [];
+    }
+  }
+}
+
+/// Mock implementation used for development and tests without native code.
+class MockDeviceMonitoring implements DeviceMonitoring {
+  @override
+  Future<void> startMonitoring() async {}
+
+  @override
+  Future<void> stopMonitoring() async {}
+
+  @override
+  Future<List<Map<String, dynamic>>> getAppUsageStats() async => [];
+
+  @override
+  Future<List<Map<String, dynamic>>> getInstalledApps() async => [];
+}
+


### PR DESCRIPTION
## Summary
- add device monitoring platform channel with method channel and mock
- mark platform channel setup as complete in roadmap
- update changelog and prompt for next step

## Testing
- `npm test`
- `pytest codex/tests`
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68974adf0be8832eb21128962e16f177