### PR TITLE
Configure MainActivity in AndroidManifest

### DIFF
--- a/codex/daten/changelog.md
+++ b/codex/daten/changelog.md
@@ -713,3 +713,7 @@
 - Tages- und Wochenaggregation sowie Batch-Upload zum Backend implementiert
 - `ActivityMonitoringService` im Service Locator registriert
 - Roadmap und Prompt aktualisiert
+
+### Phase 1: Android MainActivity Manifest Configuration - 2025-09-22
+- AndroidManifest in `flutter_app/mrs_unkwn_app` um MainActivity mit `singleTop`, `exported` und Theme-Metadaten erweitert
+- Prompt aktualisiert

--- a/codex/daten/prompt.md
+++ b/codex/daten/prompt.md
@@ -20,6 +20,7 @@
 - Phase 1 Milestone 5: Permission Request Flow für Device Monitoring abgeschlossen ✓
 - Phase 1 Milestone 5: App Usage Statistics UI Display abgeschlossen ✓
 - Phase 1 Milestone 5: Real-time Activity Monitoring Service abgeschlossen ✓
+- Phase 1 Milestone 5: Android MainActivity Manifest Configuration abgeschlossen ✓
 - Phase 1 Milestone 5: App Installation/Uninstallation Detection offen ✗
 
 ## Referenzen

--- a/flutter_app/mrs_unkwn_app/android/app/src/main/AndroidManifest.xml
+++ b/flutter_app/mrs_unkwn_app/android/app/src/main/AndroidManifest.xml
@@ -1,0 +1,21 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.mrsunkwn.mrs_unkwn_app">
+    <application
+        android:label="mrs_unkwn_app"
+        android:name="${applicationName}">
+        <activity
+            android:name=".MainActivity"
+            android:exported="true"
+            android:launchMode="singleTop"
+            android:theme="@style/LaunchTheme"
+            android:windowSoftInputMode="adjustResize">
+            <meta-data
+                android:name="io.flutter.embedding.android.NormalTheme"
+                android:resource="@style/NormalTheme" />
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+    </application>
+</manifest>


### PR DESCRIPTION
## Summary
- define exported MainActivity with singleTop launch mode and theme metadata in Android manifest
- log manifest update in changelog and prompt for next steps

## Testing
- `npm test`
- `pytest codex/tests`
- `flutter test` *(fails: Unexpected child "l10n" in pubspec)*

------
https://chatgpt.com/codex/tasks/task_e_68976df58878832e81272192e8c0d1fd