### PR TITLE
feat: add screen time tracking service

### DIFF
--- a/codex/daten/changelog.md
+++ b/codex/daten/changelog.md
@@ -722,3 +722,8 @@
 - BroadcastReceiver und EventChannel für Installations- und Deinstallationsereignisse hinzugefügt
 - `InstallMonitoringService` speichert Historie in Hive und informiert Eltern bei neuen Apps
 - Roadmap und Prompt aktualisiert
+
+### Phase 1: Basic Screen Time Tracking Implementation - 2025-09-24
+- `ScreenTimeTracker` Dienst berechnet tägliche Bildschirmzeit pro App und Gesamt
+- Limits mit Elternbenachrichtigung bei Überschreitung umgesetzt
+- Service Locator und Tests ergänzt

--- a/codex/daten/prompt.md
+++ b/codex/daten/prompt.md
@@ -1,4 +1,4 @@
-# Nächster Schritt: Basic Screen Time Tracking Implementation
+# Nächster Schritt: Device Information Collection
 
 ## Status
 - Phase 0 abgeschlossen ✓
@@ -22,7 +22,8 @@
 - Phase 1 Milestone 5: Real-time Activity Monitoring Service abgeschlossen ✓
 - Phase 1 Milestone 5: Android MainActivity Manifest Configuration abgeschlossen ✓
  - Phase 1 Milestone 5: App Installation/Uninstallation Detection abgeschlossen ✓
- - Phase 1 Milestone 5: Basic Screen Time Tracking Implementation offen ✗
+ - Phase 1 Milestone 5: Basic Screen Time Tracking Implementation abgeschlossen ✓
+ - Phase 1 Milestone 5: Device Information Collection offen ✗
 
 ## Referenzen
 - `/README.md`
@@ -31,16 +32,16 @@
 - `/codex/daten/changelog.md`
 
 ## Nächste Aufgabe
-Basic Screen Time Tracking Implementation umsetzen.
+Device Information Collection umsetzen.
 
 ### Vorbereitungen
 - `README.md` und Roadmap prüfen.
 
 ### Implementierungsschritte
-- `screen_time_tracker.dart` Service erstellen.
-- Foreground-Zeit pro App erfassen und täglich speichern.
-- Screen-Time-Limits prüfen und Warnungen auslösen.
-- Zusammenfassungen für Eltern generieren.
+- `device_info_plus` integrieren.
+- Hardware- und Betriebssysteminformationen erfassen.
+- Nutzungs- und Zustandsdaten (Speicher, Akku) speichern.
+- Daten für Parent-Dashboard aufbereiten.
 
 ### Validierung
 - Entsprechende Tests (z. B. `npm test`, `pytest codex/tests`, `flutter test`) ausführen.

--- a/codex/daten/roadmap.md
+++ b/codex/daten/roadmap.md
@@ -201,7 +201,7 @@ Details: Erstelle Background-Service für continuous App-Usage-Monitoring. Imple
  [x] App Installation/Uninstallation Detection:
  Details: BroadcastReceiver für `ACTION_PACKAGE_ADDED` und `ACTION_PACKAGE_REMOVED` implementiert, EventChannel angebunden und Installationshistorie in Hive gespeichert. Benachrichtigt Eltern über neue Apps und bereitet Approval-Workflow vor.
 
-[ ] Basic Screen Time Tracking Implementation:
+[x] Basic Screen Time Tracking Implementation:
 Details: Erstelle `screen_time_tracker.dart` Service. Implementiere Screen-Time-Calculation basierend auf App-Foreground-Time. Track Daily-Screen-Time per App und gesamt. Store Screen-Time-Data in Hive-Database mit Daily-Buckets. Implementiere Screen-Time-Limits-Checking und Warning-Notifications. Handle App-Switching-Events und Accurate-Time-Calculation. Erstelle Screen-Time-Summary-Reports für Parents.
 
 [ ] Device Information Collection:

--- a/flutter_app/mrs_unkwn_app/lib/core/di/service_locator.dart
+++ b/flutter_app/mrs_unkwn_app/lib/core/di/service_locator.dart
@@ -6,6 +6,7 @@ import '../network/dio_client.dart';
 import '../../platform_channels/device_monitoring.dart';
 import '../../features/monitoring/data/services/activity_monitoring_service.dart';
 import '../../features/monitoring/data/services/install_monitoring_service.dart';
+import '../../features/monitoring/data/services/screen_time_tracker.dart';
 import '../../features/tutoring/data/services/ai_response_service.dart';
 import '../../features/tutoring/data/services/subject_classification_service.dart';
 import '../../features/tutoring/data/services/content_moderation_service.dart';
@@ -75,6 +76,9 @@ void _registerFeatures() {
   );
   sl.registerLazySingleton<InstallMonitoringService>(
     () => InstallMonitoringService(sl(), sl()),
+  );
+  sl.registerLazySingleton<ScreenTimeTracker>(
+    () => ScreenTimeTracker(sl(), sl()),
   );
   sl.registerFactory<FamilyBloc>(() => FamilyBloc(sl(), sl()));
 }

--- a/flutter_app/mrs_unkwn_app/lib/features/monitoring/data/services/screen_time_tracker.dart
+++ b/flutter_app/mrs_unkwn_app/lib/features/monitoring/data/services/screen_time_tracker.dart
@@ -1,0 +1,143 @@
+import 'dart:async';
+
+import 'package:hive_flutter/hive_flutter.dart';
+
+import '../../../../core/utils/logger.dart';
+import '../../../../platform_channels/device_monitoring.dart';
+import '../../../tutoring/data/services/content_moderation_service.dart';
+
+/// Tracks daily screen time per app and notifies parents when limits are exceeded.
+class ScreenTimeTracker {
+  ScreenTimeTracker(this._deviceMonitoring, this._notifier);
+
+  final DeviceMonitoring _deviceMonitoring;
+  final ParentNotificationService _notifier;
+
+  static const _boxName = 'screen_time';
+  static bool _initialized = false;
+
+  Box? _box;
+  Timer? _timer;
+  final Map<String, int> _todayUsage = {};
+  Map<String, int> _lastSnapshot = {};
+  DateTime _currentDay = DateTime.now();
+
+  int? _totalLimit;
+  final Map<String, int> _appLimits = {};
+  bool _totalLimitNotified = false;
+  final Set<String> _appLimitNotified = {};
+
+  /// Initialize Hive storage.
+  Future<void> init() async {
+    if (!_initialized) {
+      await Hive.initFlutter();
+      _initialized = true;
+    }
+    if (!Hive.isBoxOpen(_boxName)) {
+      _box = await Hive.openBox(_boxName);
+    } else {
+      _box = Hive.box(_boxName);
+    }
+  }
+
+  /// Start periodic screen time tracking.
+  Future<void> start({Duration interval = const Duration(minutes: 1)}) async {
+    await init();
+    await collect();
+    _timer?.cancel();
+    _timer = Timer.periodic(interval, (_) => collect());
+  }
+
+  /// Stop periodic tracking.
+  Future<void> stop() async {
+    _timer?.cancel();
+  }
+
+  /// Manually trigger a collection cycle.
+  Future<void> collect() async {
+    try {
+      if (!await _deviceMonitoring.hasPermission()) return;
+      final stats = await _deviceMonitoring.getAppUsageStats();
+      final now = DateTime.now();
+      if (_currentDay.day != now.day ||
+          _currentDay.month != now.month ||
+          _currentDay.year != now.year) {
+        _todayUsage.clear();
+        _lastSnapshot = {};
+        _currentDay = now;
+        _totalLimitNotified = false;
+        _appLimitNotified.clear();
+      }
+      final current = <String, int>{};
+      for (final stat in stats) {
+        final pkg = stat['package'] as String? ?? 'unknown';
+        final minutes = (stat['minutes'] as num?)?.toInt() ?? 0;
+        current[pkg] = minutes;
+        final last = _lastSnapshot[pkg] ?? 0;
+        final diff = minutes - last;
+        if (diff > 0) {
+          _todayUsage[pkg] = (_todayUsage[pkg] ?? 0) + diff;
+        }
+      }
+      _lastSnapshot = current;
+      final total = _todayUsage.values.fold<int>(0, (a, b) => a + b);
+      final record = {
+        'total': total,
+        'apps': Map<String, int>.from(_todayUsage),
+        'timestamp': now.toIso8601String(),
+      };
+      final key = _dayKey(now);
+      await _box?.put(key, record);
+      _checkLimits(total);
+    } catch (e, stack) {
+      Logger.error('collect failed: $e', e, stack);
+    }
+  }
+
+  /// Set screen time limits in minutes. [total] for daily total, [perApp] for per-app limits.
+  void setLimits({int? total, Map<String, int>? perApp}) {
+    _totalLimit = total;
+    if (perApp != null) {
+      _appLimits
+        ..clear()
+        ..addAll(perApp);
+    }
+    _totalLimitNotified = false;
+    _appLimitNotified.clear();
+  }
+
+  void _checkLimits(int total) {
+    if (_totalLimit != null && total > _totalLimit! && !_totalLimitNotified) {
+      _totalLimitNotified = true;
+      _notifier.notify(
+        message: 'Tägliches Bildschirmzeitlimit überschritten',
+        categories: const [],
+      );
+    }
+    _todayUsage.forEach((pkg, minutes) {
+      final limit = _appLimits[pkg];
+      if (limit != null &&
+          minutes > limit &&
+          !_appLimitNotified.contains(pkg)) {
+        _appLimitNotified.add(pkg);
+        _notifier.notify(
+          message: 'Bildschirmzeitlimit für $pkg überschritten',
+          categories: const [],
+        );
+      }
+    });
+  }
+
+  /// Returns stored usage for [day].
+  Future<Map<String, dynamic>> dailyReport(DateTime day) async {
+    await init();
+    final data = _box?.get(_dayKey(day));
+    if (data is Map) {
+      return Map<String, dynamic>.from(data.cast<String, dynamic>());
+    }
+    return {'total': 0, 'apps': <String, int>{}};
+  }
+
+  String _dayKey(DateTime day) =>
+      '${day.year.toString().padLeft(4, '0')}-${day.month.toString().padLeft(2, '0')}-${day.day.toString().padLeft(2, '0')}';
+}

--- a/flutter_app/mrs_unkwn_app/test/screen_time_tracker_test.dart
+++ b/flutter_app/mrs_unkwn_app/test/screen_time_tracker_test.dart
@@ -1,0 +1,65 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive_flutter/hive_flutter.dart';
+import 'package:mrs_unkwn_app/features/monitoring/data/services/screen_time_tracker.dart';
+import 'package:mrs_unkwn_app/platform_channels/device_monitoring.dart';
+import 'package:mrs_unkwn_app/features/tutoring/data/services/content_moderation_service.dart';
+
+class _FakeDeviceMonitoring implements DeviceMonitoring {
+  int _minutes = 0;
+
+  @override
+  Future<bool> hasPermission() async => true;
+
+  @override
+  Future<void> requestPermission() async {}
+
+  @override
+  Future<void> openPermissionSettings() async {}
+
+  @override
+  Future<void> startMonitoring() async {}
+
+  @override
+  Future<void> stopMonitoring() async {}
+
+  @override
+  Future<List<Map<String, dynamic>>> getAppUsageStats() async {
+    _minutes += 5;
+    return [
+      {'package': 'app', 'minutes': _minutes},
+    ];
+  }
+
+  @override
+  Future<List<Map<String, dynamic>>> getInstalledApps() async => [];
+}
+
+class _FakeNotifier extends ParentNotificationService {
+  final List<String> messages = [];
+
+  @override
+  Future<void> notify({
+    required String message,
+    required List<ModerationCategory> categories,
+  }) async {
+    messages.add(message);
+  }
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('tracks usage and triggers limit notification', () async {
+    await Hive.initFlutter();
+    await Hive.deleteBoxFromDisk('screen_time');
+    final notifier = _FakeNotifier();
+    final tracker = ScreenTimeTracker(_FakeDeviceMonitoring(), notifier);
+    tracker.setLimits(total: 8);
+    await tracker.init();
+    await tracker.collect();
+    await tracker.collect();
+    final report = await tracker.dailyReport(DateTime.now());
+    expect(report['total'], 10);
+    expect(notifier.messages.length, 1);
+  });
+}


### PR DESCRIPTION
## Summary
- add `ScreenTimeTracker` to compute per-app and total daily screen time and notify parents when limits are exceeded
- register tracker in service locator and add unit tests
- mark screen time milestone complete and update roadmap, changelog, and prompt for next device info step

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest codex/tests`
- `flutter test` *(fails: Unexpected child "l10n" found under "flutter")*

------
https://chatgpt.com/codex/tasks/task_e_689778dafa2c832eaa428e0db325f2cb