### PR TITLE
feat: add OpenAI service test

### DIFF
--- a/codex/daten/changelog.md
+++ b/codex/daten/changelog.md
@@ -777,6 +777,11 @@
 - Upload-Batch dekomprimiert Daten vor Übertragung
 - Roadmap und Prompt aktualisiert
 
+### Phase 1: OpenAI API Integration Setup - 2025-10-03
+- `openai_service.dart` mit Timeout, Exponential-Backoff und Usage-Tracking implementiert
+- Service Locator um `OpenAIService` registriert
+- Unit-Test `openai_service_test.dart` mit Mock-HTTP-Client hinzugefügt
+
 ### Wartungscheck - 2025-09-15
 - `npm test` erfolgreich
 - `pytest codex/tests` ausgeführt: keine Tests gefunden

--- a/codex/daten/prompt.md
+++ b/codex/daten/prompt.md
@@ -1,4 +1,4 @@
-# Nächster Schritt: Phase 1 Milestone 6 – OpenAI API Integration Setup
+# Nächster Schritt: Phase 1 Milestone 6 – Chat Message Model und Serialization
 
 ## Status
 - Phase 0 abgeschlossen ✓
@@ -31,6 +31,7 @@
 - Phase 1 Milestone 5: Monitoring Alerts und Notifications abgeschlossen ✓
 - Phase 1 Milestone 5: Privacy und DSGVO Compliance für Monitoring abgeschlossen ✓
 - Phase 1 Milestone 5: Monitoring Performance Optimization abgeschlossen ✓
+- Phase 1 Milestone 6: OpenAI API Integration Setup abgeschlossen ✓
 - Wartungscheck am 2025-09-15 durchgeführt (npm test erfolgreich, pytest keine Tests, flutter test fehlgeschlagen)
 - Wartungscheck am 2025-09-16 durchgeführt (npm test fehlgeschlagen: package.json nicht gefunden, pytest codex/tests keine Tests gefunden, flutter test fehlgeschlagen: Testverzeichnis nicht gefunden)
 - Wartungscheck am 2025-09-17 durchgeführt (npm test fehlgeschlagen: ts-node nicht gefunden, pytest codex/tests keine Tests gefunden, flutter test fehlgeschlagen: Kompilationsfehler)
@@ -44,19 +45,17 @@
 - `/codex/daten/changelog.md`
 
 ## Nächste Aufgabe
-Phase 1 Milestone 6: OpenAI API Integration Setup implementieren.
+Phase 1 Milestone 6: Chat Message Model und Serialization implementieren.
 
 ### Vorbereitungen
 - `README.md` und Roadmap prüfen.
-- Sicherstellen, dass `http` als Dependency in `pubspec.yaml` vorhanden ist.
+- Sicherstellen, dass `json_annotation` und `build_runner` korrekt konfiguriert sind.
 
 ### Implementierungsschritte
-- Datei `lib/core/services/openai_service.dart` anlegen.
-- Klasse `OpenAIService` implementieren, die HTTP-Anfragen an die OpenAI-API sendet.
-- API-Key über Environment-Konfiguration laden und Requests mit Timeout (30s) sowie Exponential-Backoff bei Rate-Limits ausführen.
-- Methode `Future<String> sendChatRequest(String message, List<ChatMessage> context)` implementieren.
-- Service in `lib/core/di/service_locator.dart` registrieren.
-- Unit-Test `openai_service_test.dart` mit Mock HTTP-Client anlegen.
+- Datei `lib/features/tutoring/data/models/chat_message.dart` anlegen oder erweitern.
+- Klasse `ChatMessage` mit Rollen, Typen, Zeitstempel und optionalen Metadaten definieren.
+- `@JsonSerializable()` Annotation hinzufügen und `fromJson`/`toJson` Methoden generieren.
+- Unit-Test `chat_message_test.dart` mit Serialisierungs-Checks erstellen.
 
 ### Validierung
 - `npm test` ausführen.

--- a/codex/daten/roadmap.md
+++ b/codex/daten/roadmap.md
@@ -231,7 +231,7 @@ Details: Optimize Background-Service für Minimal-Battery-Impact using JobSchedu
 ### Milestone 6: Basic AI Tutoring Foundation
 
 [x] OpenAI API Integration Setup:
-Details: Installiere `http` Package für API-Requests. Erstelle `lib/core/services/openai_service.dart`. Implementiere `OpenAIService` Klasse mit API-Key aus Environment-Variables. Create Methods: `sendChatRequest(String message, List<ChatMessage> context)`. Handle API-Rate-Limiting mit Exponential-Backoff-Retry. Implement Request-Timeout-Handling (30 seconds). Store API-Usage-Statistics für Cost-Tracking.
+Details: Installiere `http` Package für API-Requests. Erstelle `lib/core/services/openai_service.dart`. Implementiere `OpenAIService` Klasse mit API-Key aus Environment-Variables. Create Methods: `sendChatRequest(String message, List<ChatMessage> context)`. Handle API-Rate-Limiting mit Exponential-Backoff-Retry. Implement Request-Timeout-Handling (30 seconds). Store API-Usage-Statistics für Cost-Tracking. Unit-Test `openai_service_test.dart` mit Mock-Client erstellen.
 
 [x] Chat Message Model und Serialization:
 Details: Erstelle `lib/features/tutoring/data/models/chat_message.dart`. Implementiere `ChatMessage` Model mit Properties: `id`, `role` (user/assistant/system), `content`, `timestamp`, `metadata`. Add `@JsonSerializable()` für Serialization. Implement `fromJson()` und `toJson()` Methods. Create Message-Types: Text, Image, File-Attachment. Handle Message-Threading für Multi-turn-Conversations.

--- a/flutter_app/mrs_unkwn_app/test/openai_service_test.dart
+++ b/flutter_app/mrs_unkwn_app/test/openai_service_test.dart
@@ -1,0 +1,59 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:http/http.dart' as http;
+import 'package:mrs_unkwn_app/core/services/openai_service.dart';
+
+class MockHttpClient extends Mock implements http.Client {}
+
+void main() {
+  setUpAll(() {
+    registerFallbackValue(Uri.parse('https://api.openai.com'));
+    registerFallbackValue(<String, String>{});
+  });
+
+  test('sendChatRequest returns content and tracks usage', () async {
+    final client = MockHttpClient();
+    when(() =>
+        client.post(any(),
+            headers: any(named: 'headers'),
+            body: any(named: 'body'))).thenAnswer((_) async => http.Response(
+        '{"choices":[{"message":{"content":"Hi"}}],"usage":{"total_tokens":7}}',
+        200));
+
+    final service = OpenAIService(client: client, wait: (_) async {});
+    final result = await service.sendChatRequest(
+        'Hello', [ChatMessage(role: 'system', content: 'You are helpful')]);
+
+    expect(result, 'Hi');
+    expect(service.requestCount, 1);
+    expect(service.totalTokens, 7);
+    verify(() => client.post(any(),
+        headers: any(named: 'headers'), body: any(named: 'body'))).called(1);
+  });
+
+  test('retries on rate limit and succeeds', () async {
+    final client = MockHttpClient();
+    var call = 0;
+    when(() => client.post(any(),
+        headers: any(named: 'headers'),
+        body: any(named: 'body'))).thenAnswer((_) async {
+      call++;
+      if (call == 1) {
+        return http.Response('rate limit', 429);
+      }
+      return http.Response(
+          '{"choices":[{"message":{"content":"ok"}}],"usage":{"total_tokens":3}}',
+          200);
+    });
+
+    final service = OpenAIService(client: client, wait: (_) async {});
+    final result = await service.sendChatRequest(
+        'Hello', [ChatMessage(role: 'system', content: 'ctx')]);
+
+    expect(result, 'ok');
+    expect(service.requestCount, 1);
+    expect(service.totalTokens, 3);
+    verify(() => client.post(any(),
+        headers: any(named: 'headers'), body: any(named: 'body'))).called(2);
+  });
+}


### PR DESCRIPTION
## Summary
- add injectable delay to OpenAIService and track usage
- cover OpenAIService with mock-based unit tests
- document OpenAI integration in roadmap, changelog, and prompt

## Testing
- `npm test` *(fails: ts-node not found)*
- `pytest codex/tests`
- `flutter test` *(fails: missing packages and compilation errors)*

------
https://chatgpt.com/codex/tasks/task_e_6897b7fa6098832e9c19ceaf14abb422