### PR TITLE
Add OpenAI service unit test and update docs

### DIFF
--- a/codex/daten/changelog.md
+++ b/codex/daten/changelog.md
@@ -777,6 +777,12 @@
 - Upload-Batch dekomprimiert Daten vor Übertragung
 - Roadmap und Prompt aktualisiert
 
+### Phase 1: OpenAI API Integration Tests - 2025-10-03
+- `OpenAIService` sendet Chat-Anfragen an OpenAI mit Timeout und Exponential-Backoff
+- Service im `service_locator.dart` registriert und HTTP Dependency bestätigt
+- Unit-Test `openai_service_test.dart` mit Mock HTTP-Client hinzugefügt
+- Roadmap und Prompt aktualisiert
+
 ### Wartungscheck - 2025-09-15
 - `npm test` erfolgreich
 - `pytest codex/tests` ausgeführt: keine Tests gefunden

--- a/codex/daten/prompt.md
+++ b/codex/daten/prompt.md
@@ -1,4 +1,4 @@
-# Nächster Schritt: Phase 1 Milestone 6 – OpenAI API Integration Setup
+# Nächster Schritt: Phase 1 Milestone 6 – Chat Message Model und Serialization
 
 ## Status
 - Phase 0 abgeschlossen ✓
@@ -31,11 +31,13 @@
 - Phase 1 Milestone 5: Monitoring Alerts und Notifications abgeschlossen ✓
 - Phase 1 Milestone 5: Privacy und DSGVO Compliance für Monitoring abgeschlossen ✓
 - Phase 1 Milestone 5: Monitoring Performance Optimization abgeschlossen ✓
+- Phase 1 Milestone 6: OpenAI API Integration Setup abgeschlossen ✓
 - Wartungscheck am 2025-09-15 durchgeführt (npm test erfolgreich, pytest keine Tests, flutter test fehlgeschlagen)
 - Wartungscheck am 2025-09-16 durchgeführt (npm test fehlgeschlagen: package.json nicht gefunden, pytest codex/tests keine Tests gefunden, flutter test fehlgeschlagen: Testverzeichnis nicht gefunden)
 - Wartungscheck am 2025-09-17 durchgeführt (npm test fehlgeschlagen: ts-node nicht gefunden, pytest codex/tests keine Tests gefunden, flutter test fehlgeschlagen: Kompilationsfehler)
 - Wartungscheck am 2025-09-18 durchgeführt (npm test fehlgeschlagen: package.json nicht gefunden, pytest codex/tests keine Tests gefunden, flutter test fehlgeschlagen: MissingPluginException und fehlende Abhängigkeiten)
 - Wartungscheck am 2025-09-19 durchgeführt (npm test fehlgeschlagen: package.json nicht gefunden, pytest codex/tests keine Tests gefunden, flutter test fehlgeschlagen: Testverzeichnis nicht gefunden)
+- Wartungscheck am 2025-10-03 durchgeführt (npm test fehlgeschlagen: ts-node not found, pytest codex/tests keine Tests, flutter test fehlgeschlagen: fehlende Firebase-Pakete)
 
 ## Referenzen
 - `/README.md`
@@ -44,19 +46,17 @@
 - `/codex/daten/changelog.md`
 
 ## Nächste Aufgabe
-Phase 1 Milestone 6: OpenAI API Integration Setup implementieren.
+Phase 1 Milestone 6: Chat Message Model und Serialization implementieren.
 
 ### Vorbereitungen
 - `README.md` und Roadmap prüfen.
-- Sicherstellen, dass `http` als Dependency in `pubspec.yaml` vorhanden ist.
 
 ### Implementierungsschritte
-- Datei `lib/core/services/openai_service.dart` anlegen.
-- Klasse `OpenAIService` implementieren, die HTTP-Anfragen an die OpenAI-API sendet.
-- API-Key über Environment-Konfiguration laden und Requests mit Timeout (30s) sowie Exponential-Backoff bei Rate-Limits ausführen.
-- Methode `Future<String> sendChatRequest(String message, List<ChatMessage> context)` implementieren.
-- Service in `lib/core/di/service_locator.dart` registrieren.
-- Unit-Test `openai_service_test.dart` mit Mock HTTP-Client anlegen.
+- Datei `lib/features/tutoring/data/models/chat_message.dart` anlegen.
+- `ChatMessage` Modell mit Feldern `id`, `role`, `content`, `timestamp` und `metadata` sowie `ChatMessageType` implementieren.
+- `@JsonSerializable()` nutzen und `fromJson()`/`toJson()` Methoden generieren.
+- Typen `text`, `image` und `file` unterstützen und Message-Threading für Multi-Turn-Konversationen berücksichtigen.
+- Unit-Test `chat_message_test.dart` mit Beispielserialisierung hinzufügen.
 
 ### Validierung
 - `npm test` ausführen.

--- a/codex/daten/roadmap.md
+++ b/codex/daten/roadmap.md
@@ -423,3 +423,5 @@ Details: Endpoint liefert aktuelle Modellversion und letztes Trainingsdatum.
 - [x] Wartungscheck am 2025-09-18: Tests (`npm test` fehlgeschlagen: package.json nicht gefunden, `pytest codex/tests` keine Tests gefunden, `flutter test` fehlgeschlagen: MissingPluginException und fehlende Abhängigkeiten)
 
 - [x] Wartungscheck am 2025-09-19: Tests (`npm test` fehlgeschlagen: package.json nicht gefunden, `pytest codex/tests` keine Tests gefunden, `flutter test` fehlgeschlagen: Testverzeichnis nicht gefunden)
+
+- [x] Wartungscheck am 2025-10-03: Tests (`npm test` fehlgeschlagen: ts-node not found, `pytest codex/tests` keine Tests gefunden, `flutter test` fehlgeschlagen: fehlende Firebase-Pakete)

--- a/flutter_app/mrs_unkwn_app/test/openai_service_test.dart
+++ b/flutter_app/mrs_unkwn_app/test/openai_service_test.dart
@@ -1,0 +1,47 @@
+import 'dart:convert';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:http/http.dart' as http;
+import 'package:mrs_unkwn_app/core/services/openai_service.dart';
+
+class MockHttpClient extends Mock implements http.Client {}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUpAll(() {
+    registerFallbackValue(Uri());
+  });
+
+  test('sendChatRequest returns response and tracks usage', () async {
+    final client = MockHttpClient();
+    final service = OpenAIService(client: client);
+
+    when(() => client.post(any(),
+        headers: any(named: 'headers'), body: any(named: 'body'))).thenAnswer(
+      (_) async => http.Response(
+        jsonEncode({
+          'choices': [
+            {
+              'message': {'content': 'Hello'}
+            }
+          ],
+          'usage': {'total_tokens': 21}
+        }),
+        200,
+      ),
+    );
+
+    final result = await service.sendChatRequest('Hi', []);
+
+    expect(result, 'Hello');
+    expect(service.requestCount, 1);
+    expect(service.totalTokens, 21);
+
+    verify(() => client.post(
+          Uri.parse('https://api.openai.com/v1/chat/completions'),
+          headers: any(named: 'headers'),
+          body: any(named: 'body'),
+        )).called(1);
+  });
+}


### PR DESCRIPTION
## Summary
- test OpenAIService with a mock HTTP client to verify request/usage tracking
- log OpenAI integration tests in changelog and update next-step prompt
- record latest maintenance check in roadmap

## Testing
- `npm test --prefix backend` *(fails: ts-node not found)*
- `pytest codex/tests`
- `cd flutter_app/mrs_unkwn_app && flutter test` *(fails: missing firebase packages)*

------
https://chatgpt.com/codex/tasks/task_e_6897b7de09d4832eb8e382126c9076ff