### PR TITLE
Add unit test for Socratic prompt generation

### DIFF
--- a/codex/daten/changelog.md
+++ b/codex/daten/changelog.md
@@ -807,3 +807,8 @@
 ### Phase 1: Chat Message Model und Serialization - 2025-10-04
 - `chat_message_test.dart` hinzugefügt zur Überprüfung der JSON-Serialisierung
 - Roadmap und Prompt aktualisiert
+
+### Phase 1: AI Prompt Engineering für Sokratische Methode - 2025-10-05
+- `socratic_prompts.dart` um altersgerechte System-Prompts und Kontextkürzung erweitert
+- Unit-Test `socratic_prompts_test.dart` zur Überprüfung der Prompt-Generierung hinzugefügt
+- Roadmap und Prompt aktualisiert

--- a/codex/daten/prompt.md
+++ b/codex/daten/prompt.md
@@ -1,4 +1,4 @@
-# Nächster Schritt: Phase 1 Milestone 6 – AI Prompt Engineering für Sokratische Methode
+# Nächster Schritt: Phase 1 Milestone 6 – Chat UI Interface Implementation
 
 ## Status
 - Phase 0 abgeschlossen ✓
@@ -33,6 +33,7 @@
 - Phase 1 Milestone 5: Monitoring Performance Optimization abgeschlossen ✓
 - Phase 1 Milestone 6: OpenAI API Integration Setup abgeschlossen ✓
 - Phase 1 Milestone 6: Chat Message Model und Serialization abgeschlossen ✓
+- Phase 1 Milestone 6: AI Prompt Engineering für Sokratische Methode abgeschlossen ✓
 - Wartungscheck am 2025-09-15 durchgeführt (npm test erfolgreich, pytest keine Tests, flutter test fehlgeschlagen)
 - Wartungscheck am 2025-09-16 durchgeführt (npm test fehlgeschlagen: package.json nicht gefunden, pytest codex/tests keine Tests gefunden, flutter test fehlgeschlagen: Testverzeichnis nicht gefunden)
 - Wartungscheck am 2025-09-17 durchgeführt (npm test fehlgeschlagen: ts-node nicht gefunden, pytest codex/tests keine Tests gefunden, flutter test fehlgeschlagen: Kompilationsfehler)
@@ -46,18 +47,19 @@
 - `/codex/daten/changelog.md`
 
 ## Nächste Aufgabe
-Phase 1 Milestone 6: AI Prompt Engineering für Sokratische Methode implementieren.
+Phase 1 Milestone 6: Chat UI Interface Implementation umsetzen.
 
 ### Vorbereitungen
 - README und Roadmap prüfen.
 - Sicherstellen, dass `chat_message.dart` verfügbar ist.
 
 ### Implementierungsschritte
-- Datei `lib/features/tutoring/data/prompts/socratic_prompts.dart` anlegen oder erweitern.
-- `TutoringSubject` Enum und System-Prompts für Mathematik, Naturwissenschaften, Literatur und Geschichte definieren.
-- `SocraticPrompts` Klasse mit Methoden `systemPrompt` und `buildPrompt` erstellen.
-- Hilfsfunktionen zum Kürzen der Historie (`_trimHistory`) und Token-Zählung (`_countTokens`) implementieren.
-- Unit-Test `socratic_prompts_test.dart` für Prompt-Generierung hinzufügen.
+- Datei `lib/features/tutoring/presentation/pages/chat_page.dart` anlegen oder erweitern.
+- Chat-Bubble-UI mit Sender-Differenzierung (Student vs AI) implementieren.
+- Message-Input-Feld mit Send-Button und optionaler Voice-Input-Funktion bereitstellen.
+- Auto-Scroll zu neuesten Nachrichten und Möglichkeit zum Laden älterer Historie ergänzen.
+- Typing-Indicators während der AI-Antwort anzeigen.
+- Message-Delivery-Status (Sending, Sent, Error) visuell darstellen.
 
 ### Validierung
 - `npm test` ausführen.

--- a/codex/daten/roadmap.md
+++ b/codex/daten/roadmap.md
@@ -238,7 +238,7 @@ Details: Erstelle `lib/features/tutoring/data/models/chat_message.dart`. Impleme
 - Unit-Test `chat_message_test.dart` ergänzt.
 
 [x] AI Prompt Engineering für Sokratische Methode:
-Details: Erstelle `lib/features/tutoring/data/prompts/socratic_prompts.dart`. Define System-Prompts für verschiedene Subjects: Math, Science, Literature, History. Implement Prompt-Templates die Socratic-Questioning fördern: "Instead of giving the answer, ask a guiding question". Create Age-appropriate-Prompts für Different-Grade-Levels. Implement Context-Building für Previous-Conversation-History. Handle Prompt-Length-Limits und Token-Management.
+Details: Erstelle `lib/features/tutoring/data/prompts/socratic_prompts.dart`. Define System-Prompts für verschiedene Subjects: Math, Science, Literature, History. Implement Prompt-Templates die Socratic-Questioning fördern: "Instead of giving the answer, ask a guiding question". Create Age-appropriate-Prompts für Different-Grade-Levels. Implement Context-Building für Previous-Conversation-History. Handle Prompt-Length-Limits und Token-Management. Unit-Test `socratic_prompts_test.dart` ergänzt.
 
 [x] Chat UI Interface Implementation:
 Details: Erstelle `lib/features/tutoring/presentation/pages/chat_page.dart`. Implementiere Chat-Bubble-UI mit Sender-Differentiation (Student vs AI). Create Message-Input-Field mit Send-Button und Voice-Input-Option. Implement Auto-Scroll zu newest Messages und Load-More-History. Add Typing-Indicators during AI-Response-Generation. Handle Message-Delivery-Status (Sending, Sent, Error) mit Visual-Indicators.

--- a/flutter_app/mrs_unkwn_app/test/unit/tutoring/socratic_prompts_test.dart
+++ b/flutter_app/mrs_unkwn_app/test/unit/tutoring/socratic_prompts_test.dart
@@ -1,0 +1,55 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mrs_unkwn_app/features/tutoring/data/models/chat_message.dart';
+import 'package:mrs_unkwn_app/features/tutoring/data/prompts/socratic_prompts.dart';
+
+void main() {
+  group('SocraticPrompts', () {
+    test('systemPrompt injects age', () {
+      final prompt = SocraticPrompts.systemPrompt(
+        TutoringSubject.math,
+        age: 14,
+      );
+      expect(prompt, contains('14-year-old'));
+    });
+
+    test('buildPrompt trims history and formats conversation', () {
+      final history = [
+        ChatMessage(
+          id: '1',
+          role: ChatRole.user,
+          type: ChatMessageType.text,
+          content: 'Old message',
+          timestamp: DateTime.parse('2025-10-05T12:00:00Z'),
+        ),
+        ChatMessage(
+          id: '2',
+          role: ChatRole.assistant,
+          type: ChatMessageType.text,
+          content: 'Response',
+          timestamp: DateTime.parse('2025-10-05T12:01:00Z'),
+        ),
+        ChatMessage(
+          id: '3',
+          role: ChatRole.user,
+          type: ChatMessageType.text,
+          content: 'Recent question',
+          timestamp: DateTime.parse('2025-10-05T12:02:00Z'),
+        ),
+      ];
+
+      final result = SocraticPrompts.buildPrompt(
+        subject: TutoringSubject.math,
+        age: 14,
+        history: history,
+        question: 'New question',
+        maxContextTokens: 4,
+      );
+
+      expect(result, isNot(contains('Old message')));
+      expect(result, contains('Tutor: Response'));
+      expect(result, contains('Student: Recent question'));
+      expect(result, contains('Student: New question'));
+      expect(result.trimRight(), endsWith('Tutor:'));
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Document Socratic prompt engineering milestone and note accompanying test in roadmap and changelog
- Add unit test validating age-specific prompts and trimmed history
- Advance prompt to next task: Chat UI interface implementation

## Testing
- `npm test` *(fails: package.json not found)*
- `pytest codex/tests`
- `flutter test` *(fails: missing Firebase packages and compile errors)*

------
https://chatgpt.com/codex/tasks/task_e_68983edcfe08832e80e248cd731f3c79