### PR TITLE
feat: persist chat history and improve chat UI

### DIFF
--- a/codex/daten/changelog.md
+++ b/codex/daten/changelog.md
@@ -812,3 +812,8 @@
 - `socratic_prompts.dart` um altersgerechte System-Prompts und Kontextkürzung erweitert
 - Unit-Test `socratic_prompts_test.dart` zur Überprüfung der Prompt-Generierung hinzugefügt
 - Roadmap und Prompt aktualisiert
+
+### Phase 1: Chat UI Interface Implementation - 2025-10-06
+- `chat_page.dart` um Chat-Historie, Scroll-Logik und Ladeindikatoren erweitert
+- Sprachaufnahme- und Sende-Status visualisiert, Nachrichten in `ChatHistoryService` gespeichert
+- Prompt aktualisiert

--- a/codex/daten/prompt.md
+++ b/codex/daten/prompt.md
@@ -1,4 +1,4 @@
-# Nächster Schritt: Phase 1 Milestone 6 – Chat UI Interface Implementation
+# Nächster Schritt: Phase 1 Milestone 6 – AI Response Generation Service
 
 ## Status
 - Phase 0 abgeschlossen ✓
@@ -34,6 +34,7 @@
 - Phase 1 Milestone 6: OpenAI API Integration Setup abgeschlossen ✓
 - Phase 1 Milestone 6: Chat Message Model und Serialization abgeschlossen ✓
 - Phase 1 Milestone 6: AI Prompt Engineering für Sokratische Methode abgeschlossen ✓
+- Phase 1 Milestone 6: Chat UI Interface Implementation abgeschlossen ✓
 - Wartungscheck am 2025-09-15 durchgeführt (npm test erfolgreich, pytest keine Tests, flutter test fehlgeschlagen)
 - Wartungscheck am 2025-09-16 durchgeführt (npm test fehlgeschlagen: package.json nicht gefunden, pytest codex/tests keine Tests gefunden, flutter test fehlgeschlagen: Testverzeichnis nicht gefunden)
 - Wartungscheck am 2025-09-17 durchgeführt (npm test fehlgeschlagen: ts-node nicht gefunden, pytest codex/tests keine Tests gefunden, flutter test fehlgeschlagen: Kompilationsfehler)
@@ -47,19 +48,18 @@
 - `/codex/daten/changelog.md`
 
 ## Nächste Aufgabe
-Phase 1 Milestone 6: Chat UI Interface Implementation umsetzen.
+Phase 1 Milestone 6: AI Response Generation Service umsetzen.
 
 ### Vorbereitungen
 - README und Roadmap prüfen.
-- Sicherstellen, dass `chat_message.dart` verfügbar ist.
+- Sicherstellen, dass `chat_message.dart` und `openai_service.dart` verfügbar sind.
 
 ### Implementierungsschritte
-- Datei `lib/features/tutoring/presentation/pages/chat_page.dart` anlegen oder erweitern.
-- Chat-Bubble-UI mit Sender-Differenzierung (Student vs AI) implementieren.
-- Message-Input-Feld mit Send-Button und optionaler Voice-Input-Funktion bereitstellen.
-- Auto-Scroll zu neuesten Nachrichten und Möglichkeit zum Laden älterer Historie ergänzen.
-- Typing-Indicators während der AI-Antwort anzeigen.
-- Message-Delivery-Status (Sending, Sent, Error) visuell darstellen.
+- Datei `lib/features/tutoring/data/services/ai_response_service.dart` erstellen oder erweitern.
+- Request-Building mit Gesprächskontext und System-Prompts implementieren.
+- Streaming-Responses für Echtzeit-Anzeige der Antwort unterstützen.
+- Content-Filtering und Caching für ähnliche Fragen hinzufügen.
+- Fehler robust behandeln und nutzerfreundliche Meldungen liefern.
 
 ### Validierung
 - `npm test` ausführen.


### PR DESCRIPTION
## Summary
- load existing chat messages using ChatHistoryService and paginate older history
- store sent and AI messages with delivery states and lazy scroll updates
- document chat UI completion and set next task to AI response service

## Testing
- `npm test --prefix backend` *(failed: ts-node not found)*
- `pytest codex/tests`
- `cd flutter_app/mrs_unkwn_app && flutter test` *(failed: firebase packages missing)*

------
https://chatgpt.com/codex/tasks/task_e_68984312f4b4832e839bebf0a22326c9