### PR TITLE
test: add subject classification service tests

### DIFF
--- a/codex/daten/changelog.md
+++ b/codex/daten/changelog.md
@@ -822,3 +822,7 @@
 - `ai_response_service.dart` streamt Antworten mit Cache und Inhaltsfilter
 - `openai_service.dart` unterstützt Streaming-Anfragen an die OpenAI API
 - Roadmap und Prompt aktualisiert
+
+### Phase 1: Subject Classification System Tests - 2025-10-08
+- Unit-Tests für SubjectClassificationService mit Keyword-Erkennung, Historien-Tracking und Wechselerkennung hinzugefügt
+- Roadmap und Prompt aktualisiert

--- a/codex/daten/prompt.md
+++ b/codex/daten/prompt.md
@@ -1,4 +1,4 @@
-# Nächster Schritt: Phase 1 Milestone 6 – Subject Classification System
+# Nächster Schritt: Phase 1 Milestone 6 – Learning Session Management
 
 ## Status
 - Phase 0 abgeschlossen ✓
@@ -36,6 +36,7 @@
 - Phase 1 Milestone 6: AI Prompt Engineering für Sokratische Methode abgeschlossen ✓
 - Phase 1 Milestone 6: Chat UI Interface Implementation abgeschlossen ✓
 - Phase 1 Milestone 6: AI Response Generation Service abgeschlossen ✓
+- Phase 1 Milestone 6: Subject Classification System abgeschlossen ✓
 - Wartungscheck am 2025-09-15 durchgeführt (npm test erfolgreich, pytest keine Tests, flutter test fehlgeschlagen)
 - Wartungscheck am 2025-09-16 durchgeführt (npm test fehlgeschlagen: package.json nicht gefunden, pytest codex/tests keine Tests gefunden, flutter test fehlgeschlagen: Testverzeichnis nicht gefunden)
 - Wartungscheck am 2025-09-17 durchgeführt (npm test fehlgeschlagen: ts-node nicht gefunden, pytest codex/tests keine Tests gefunden, flutter test fehlgeschlagen: Kompilationsfehler)
@@ -49,18 +50,18 @@
 - `/codex/daten/changelog.md`
 
 ## Nächste Aufgabe
-Phase 1 Milestone 6: Subject Classification System umsetzen.
+Phase 1 Milestone 6: Learning Session Management umsetzen.
 
 ### Vorbereitungen
 - README und Roadmap prüfen.
-- Sicherstellen, dass `subject_classification_service.dart` angelegt ist.
+- Sicherstellen, dass `learning_session.dart` Modell existiert.
 
 ### Implementierungsschritte
-- Datei `lib/features/tutoring/data/services/subject_classification_service.dart` erstellen oder erweitern.
-- Keyword-basierte Klassifikation mit Historien-Tracking implementieren.
-- Erkennung von Fachwechseln zwischen aufeinanderfolgenden Fragen hinzufügen.
-- Platzhalter für zukünftiges ML-basiertes Modell einfügen.
-- Öffentliche Methoden mit Unit-Tests absichern.
+- Datei `lib/features/tutoring/data/models/learning_session.dart` erweitern, falls notwendig.
+- Session-Start- und End-Logik mit Dauerberechnung implementieren.
+- Lernmetriken (Fragenanzahl, Themen, AI-Interaktionen) erfassen und lokal speichern.
+- Sync-Mechanismus zum Backend vorbereiten.
+- Unit-Tests für das Session-Tracking hinzufügen.
 
 ### Validierung
 - `npm test` ausführen.

--- a/flutter_app/mrs_unkwn_app/test/subject_classification_service_test.dart
+++ b/flutter_app/mrs_unkwn_app/test/subject_classification_service_test.dart
@@ -1,0 +1,41 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mrs_unkwn_app/features/tutoring/data/services/subject_classification_service.dart';
+
+void main() {
+  group('SubjectClassificationService', () {
+    test('classifies math question and updates history', () {
+      final service = SubjectClassificationService();
+      final result = service.classify('How do I solve this equation?');
+      expect(result, contains('math'));
+      expect(service.history, contains('math'));
+      expect(service.subjectSwitched, isFalse);
+    });
+
+    test('detects multiple subjects in a question', () {
+      final service = SubjectClassificationService();
+      final result = service.classify('This experiment uses geometry and chemistry.');
+      expect(result, containsAll(<String>['science', 'math']));
+      expect(service.subjectSwitched, isFalse);
+    });
+
+    test('flags subject switch between consecutive questions', () {
+      final service = SubjectClassificationService();
+      service.classify('Explain the process of photosynthesis.');
+      expect(service.subjectSwitched, isFalse);
+      service.classify('Solve the integral of x squared.');
+      expect(service.subjectSwitched, isTrue);
+    });
+
+    test('classifyWithModel falls back to classify', () async {
+      final service = SubjectClassificationService();
+      final result = await service.classifyWithModel('Who was the first president of the US?');
+      expect(result, contains('history'));
+    });
+
+    test('returns unknown when no keyword matches', () {
+      final service = SubjectClassificationService();
+      final result = service.classify('Please bake a cake.');
+      expect(result, contains('unknown'));
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- add tests for subject classification service covering keyword detection, history tracking and subject switches
- document subject classification tests in changelog
- update prompt for next task on learning session management

## Testing
- `npm test` (fails: package.json not found)
- `cd backend && npm test` (fails: ts-node not found)
- `pytest codex/tests`
- `cd flutter_app/mrs_unkwn_app && flutter test` (fails: Missing packages and plugin implementations)


------
https://chatgpt.com/codex/tasks/task_e_68984b7e6bd0832e85b6480d2c7b0ece