### PR TITLE
feat: integrate voice input with tutoring bloc

### DIFF
--- a/codex/daten/changelog.md
+++ b/codex/daten/changelog.md
@@ -838,3 +838,9 @@
 - `tutoring_bloc.dart` mit Events für Nachrichtenversand und Sitzungssteuerung erstellt
 - Chatverlauf wird lokal gespeichert und optimistisch aktualisiert
 - Roadmap und Prompt aktualisiert
+
+### Phase 1: Voice Input Integration - 2025-10-11
+- `speech_to_text` als Dependency in `pubspec.yaml` hinzugefügt
+- `VoiceInputService` und `chat_page.dart` leiten erkannte Sprache an den `TutoringBloc` weiter
+- Service Locator um Registrierung des `TutoringBloc` erweitert
+- Roadmap und Prompt aktualisiert

--- a/codex/daten/prompt.md
+++ b/codex/daten/prompt.md
@@ -1,4 +1,4 @@
-# Nächster Schritt: Phase 1 Milestone 6 – Voice Input Integration
+# Nächster Schritt: Phase 1 Milestone 6 – Basic Content Moderation
 
 ## Status
 - Phase 0 abgeschlossen ✓
@@ -39,6 +39,7 @@
 - Phase 1 Milestone 6: Subject Classification System abgeschlossen ✓
 - Phase 1 Milestone 6: Learning Session Management abgeschlossen ✓
 - Phase 1 Milestone 6: AI Tutoring BLoC State Management abgeschlossen ✓
+- Phase 1 Milestone 6: Voice Input Integration abgeschlossen ✓
 - Wartungscheck am 2025-09-15 durchgeführt (npm test erfolgreich, pytest keine Tests, flutter test fehlgeschlagen)
 - Wartungscheck am 2025-09-16 durchgeführt (npm test fehlgeschlagen: package.json nicht gefunden, pytest codex/tests keine Tests gefunden, flutter test fehlgeschlagen: Testverzeichnis nicht gefunden)
 - Wartungscheck am 2025-09-17 durchgeführt (npm test fehlgeschlagen: ts-node nicht gefunden, pytest codex/tests keine Tests gefunden, flutter test fehlgeschlagen: Kompilationsfehler)
@@ -52,16 +53,16 @@
 - `/codex/daten/changelog.md`
 
 ## Nächste Aufgabe
-Phase 1 Milestone 6: Voice Input Integration umsetzen.
+Phase 1 Milestone 6: Basic Content Moderation umsetzen.
 
 ### Vorbereitungen
 - README und Roadmap prüfen.
 
 ### Implementierungsschritte
-- Dependency `speech_to_text` in `pubspec.yaml` eintragen.
-- Sprachaufnahme-Button in `chat_page.dart` ergänzen.
-- Service `VoiceInputService` für Speech-to-Text-Erkennung implementieren.
-- Erkannten Text in den Nachrichtenfluss des `TutoringBloc` einspeisen.
+- Keyword-Listen (Profanity, Violence, Adult) in `ContentModerationService` integrieren.
+- Nutzereingaben vor dem Senden durch `ContentModerationService` prüfen.
+- Verletzungen protokollieren und `ParentNotificationService` informieren.
+- Unit-Test für Content-Moderation ergänzen.
 
 ### Validierung
 - `npm test` ausführen.

--- a/codex/daten/roadmap.md
+++ b/codex/daten/roadmap.md
@@ -260,7 +260,7 @@ Details: Erstelle `tutoring_bloc.dart` mit Events: `SendMessageRequested`, `Load
   speichert Chatverläufe lokal und aktualisiert den Verlauf optimistisch.
 
 [x] Voice Input Integration:
-Details: Add `speech_to_text` Package für Voice-Input-Support. Implement Voice-Recording-UI mit Visual-Feedback (Waveform, Recording-Timer). Handle Speech-to-Text-Conversion mit Error-Handling für unclear Speech. Implement Language-Detection für Multi-language-Support (German, English). Add Voice-Commands für Navigation (Send-Message, Clear-Chat). Handle Microphone-Permissions und Audio-Recording-Privacy.
+Details: Add `speech_to_text` Package für Voice-Input-Support. Implement Voice-Recording-UI mit Visual-Feedback (Waveform, Recording-Timer). Handle Speech-to-Text-Conversion mit Error-Handling für unclear Speech. Implement Language-Detection für Multi-language-Support (German, English). Add Voice-Commands für Navigation (Send-Message, Clear-Chat). Handle Microphone-Permissions und Audio-Recording-Privacy. Weiterleitung des erkannten Textes an den `TutoringBloc` für die weitere Verarbeitung.
 
 [x] Basic Content Moderation:
 Details: Implement Client-side-Content-Filtering für Student-Messages vor AI-Submission. Create Inappropriate-Content-Detection mit Keyword-Lists: Profanity, Violence, Adult-Content. Implement AI-Response-Filtering für Educational-Appropriateness. Handle Content-Violation-Cases mit Parent-Notifications. Create Content-Appeal-Process für False-Positives. Store Moderation-Logs für Compliance und Improvement.

--- a/flutter_app/mrs_unkwn_app/lib/core/di/service_locator.dart
+++ b/flutter_app/mrs_unkwn_app/lib/core/di/service_locator.dart
@@ -28,6 +28,7 @@ import '../../features/family/data/repositories/family_repository_impl.dart';
 import '../../features/family/data/repositories/family_repository.dart';
 import '../../features/family/presentation/bloc/family_bloc.dart';
 import '../../features/family/data/services/family_service.dart';
+import '../../features/tutoring/presentation/bloc/tutoring_bloc.dart';
 
 final sl = GetIt.instance;
 
@@ -109,6 +110,17 @@ void _registerFeatures() {
     () => MonitoringPrivacyService(),
   );
   sl.registerFactory<FamilyBloc>(() => FamilyBloc(sl(), sl()));
+  sl.registerLazySingleton<TutoringBloc>(
+    () => TutoringBloc(
+      aiService: sl(),
+      classifier: sl(),
+      moderator: sl(),
+      logService: sl(),
+      notifier: sl(),
+      analytics: sl(),
+      history: sl(),
+    ),
+  );
 }
 
 void _registerExternal() {

--- a/flutter_app/mrs_unkwn_app/lib/features/tutoring/presentation/pages/chat_page.dart
+++ b/flutter_app/mrs_unkwn_app/lib/features/tutoring/presentation/pages/chat_page.dart
@@ -7,6 +7,7 @@ import '../../data/models/chat_message.dart';
 import '../../data/services/chat_history_service.dart';
 import '../../data/services/voice_input_service.dart';
 import '../../../../core/di/service_locator.dart';
+import '../bloc/tutoring_bloc.dart';
 
 enum MessageStatus { sending, sent, error }
 
@@ -83,6 +84,7 @@ class _ChatPageState extends State<ChatPage> {
     });
     _scrollToBottom();
     unawaited(_historyService.addMessage(message));
+    sl<TutoringBloc>().add(SendMessageRequested(text, age: 14));
 
     Future.delayed(const Duration(milliseconds: 500), () {
       setState(() {
@@ -109,6 +111,7 @@ class _ChatPageState extends State<ChatPage> {
       _clearChat();
     } else {
       setState(() => _controller.text = text);
+      _sendMessage();
     }
   }
 

--- a/flutter_app/mrs_unkwn_app/pubspec.yaml
+++ b/flutter_app/mrs_unkwn_app/pubspec.yaml
@@ -29,6 +29,7 @@ dependencies:
   geolocator: ^10.1.0
   encrypt: ^5.0.1
   http: ^1.1.0
+  speech_to_text: ^6.3.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- wire speech input into TutoringBloc
- register TutoringBloc in service locator
- document voice input integration and prepare next content moderation step

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest codex/tests`
- `flutter test` *(dependency updates printed)*

------
https://chatgpt.com/codex/tasks/task_e_689858209394832eac319ce57980d06c