### PR TITLE
chore: add root npm test script

### DIFF
--- a/codex/daten/changelog.md
+++ b/codex/daten/changelog.md
@@ -870,3 +870,7 @@
 - `MainActivity.kt` mit korrektem Package hinzugefügt
 - `flutter.embedding=2` in `android/gradle.properties` eingetragen
 - Flutter-Caches bereinigt und `flutter clean` ausgeführt
+### Wartungscheck - 2025-10-16
+- `npm test` erfolgreich
+- `pytest codex/tests` ausgeführt: keine Tests gefunden
+- `flutter test` fehlgeschlagen: Testverzeichnis nicht gefunden

--- a/codex/daten/prompt.md
+++ b/codex/daten/prompt.md
@@ -53,6 +53,8 @@
 
 - Wartungscheck am 2025-10-15 durchgeführt (npm test fehlgeschlagen: package.json nicht gefunden, pytest codex/tests keine Tests gefunden, flutter test hängt beim Laden der Tests)
 
+- Wartungscheck am 2025-10-16 durchgeführt (npm test erfolgreich, pytest codex/tests keine Tests gefunden, flutter test fehlgeschlagen: Testverzeichnis nicht gefunden)
+
 ## Referenzen
 - `/README.md`
 - `/codex/AGENTS.md`

--- a/codex/daten/roadmap.md
+++ b/codex/daten/roadmap.md
@@ -437,3 +437,4 @@ Details: Endpoint liefert aktuelle Modellversion und letztes Trainingsdatum.
 - [x] Wartungscheck am 2025-09-18: Tests (`npm test` fehlgeschlagen: package.json nicht gefunden, `pytest codex/tests` keine Tests gefunden, `flutter test` fehlgeschlagen: MissingPluginException und fehlende Abhängigkeiten)
 
 - [x] Wartungscheck am 2025-09-19: Tests (`npm test` fehlgeschlagen: package.json nicht gefunden, `pytest codex/tests` keine Tests gefunden, `flutter test` fehlgeschlagen: Testverzeichnis nicht gefunden)
+- [x] Wartungscheck am 2025-10-16: Tests (`npm test` erfolgreich, `pytest codex/tests` keine Tests gefunden, `flutter test` fehlgeschlagen: Testverzeichnis nicht gefunden)

--- a/package.json
+++ b/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "mrs-unkwn",
+  "private": true,
+  "version": "1.0.0",
+  "description": "Root configuration for project scripts",
+  "scripts": {
+    "test": "npm --prefix backend test"
+  }
+}


### PR DESCRIPTION
## Summary
- add root `package.json` with test script that delegates to backend tests
- record maintenance test results in changelog, prompt, and roadmap

## Testing
- `npm test`
- `pytest codex/tests`
- `flutter test` *(fails: Test directory not found)*

------
https://chatgpt.com/codex/tasks/task_e_6898761b307c832e8391543a2eb3ee03