### PR TITLE
chore: fix flutter analyze warnings and update roadmap

### DIFF
--- a/codex/daten/changelog.md
+++ b/codex/daten/changelog.md
@@ -874,3 +874,8 @@
 - `npm test` erfolgreich
 - `pytest codex/tests` ausgeführt: keine Tests gefunden
 - `flutter test` fehlgeschlagen: Testverzeichnis nicht gefunden
+
+### Wartung: Flutter Analyze Cleanup - 2025-10-17
+- `flutter analyze` ausgeführt und gemeldete Fehler/Warnungen behoben
+- AndroidManifest auf Flutter Embedding v2 bereinigt
+- Roadmap-Eintrag für Multi-Platform-Support wieder geöffnet

--- a/codex/daten/prompt.md
+++ b/codex/daten/prompt.md
@@ -2,6 +2,7 @@
 
 ## Status
 - Phase 0 abgeschlossen ✓
+- Flutter-Projekt mit Multi-Platform-Support offen ✗ (Windows/macOS/Linux fehlen)
 - Phase 1 Milestone 4: Family Creation UI Screen abgeschlossen ✓
 - Phase 1 Milestone 4: Family Model und Data Classes abgeschlossen ✓
 - Phase 1 Milestone 4: Family Repository Implementation abgeschlossen ✓

--- a/codex/daten/roadmap.md
+++ b/codex/daten/roadmap.md
@@ -19,8 +19,9 @@ Details: Erstelle ein neues Git-Repository mit `git init`. Füge eine .gitignore
 [x] Flutter SDK installieren und Entwicklungsumgebung einrichten:
 Details: Lade Flutter SDK von flutter.dev herunter. Extrahiere das SDK nach `C:\flutter` (Windows) oder `~/flutter` (macOS/Linux). Füge Flutter-Pfad zur PATH-Umgebungsvariable hinzu. Führe `flutter doctor` aus und behebe alle gemeldeten Probleme. Installiere Android Studio oder VS Code mit Flutter/Dart-Erweiterungen. Konfiguriere Android SDK mit API Level 21+ und iOS Deployment Target 11.0+.
 
-[x] Flutter-Projekt mit Multi-Platform-Support erstellen:
+[ ] Flutter-Projekt mit Multi-Platform-Support erstellen:
 Details: Navigiere in den `flutter_app/`-Ordner. Führe `flutter create --org com.mrsunkwn --platforms android,ios,web,windows,macos,linux mrs_unkwn_app` aus. Öffne `pubspec.yaml` und setze `flutter` Version auf minimum "3.16.0". Entferne Standard-Demo-Code aus `lib/main.dart`. Erstelle Basis-Ordnerstruktur in `lib/`: `core/`, `features/`, `shared/`, `platform_channels/`.
+Kommentar: Windows-, macOS- und Linux-Verzeichnisse fehlen noch; `flutter create` mit allen Plattformen erneut ausführen.
 
 [x] pubspec.yaml mit erforderlichen Dependencies konfigurieren:
 Details: Öffne `pubspec.yaml` und füge folgende dependencies hinzu unter `dependencies:`: `dio: ^5.3.0` (HTTP client), `flutter_bloc: ^8.1.3` (State Management), `get_it: ^7.6.0` (Dependency Injection), `flutter_secure_storage: ^9.0.0` (Secure Storage), `go_router: ^12.0.0` (Navigation), `hive: ^2.2.3` (Local Database), `json_annotation: ^4.8.1` (JSON Serialization). Unter `dev_dependencies:` füge hinzu: `build_runner: ^2.4.7`, `json_serializable: ^6.7.1`, `flutter_test:`, `mocktail: ^1.0.0`.

--- a/flutter_app/mrs_unkwn_app/android/app/src/main/AndroidManifest.xml
+++ b/flutter_app/mrs_unkwn_app/android/app/src/main/AndroidManifest.xml
@@ -1,8 +1,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.mrsunkwn.mrs_unkwn_app">
     <application
-        android:label="mrs_unkwn_app"
-        android:name="io.flutter.app.FlutterApplication">
+        android:label="mrs_unkwn_app">
         <activity
             android:name=".MainActivity"
             android:exported="true"
@@ -17,8 +16,5 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
-        <meta-data
-            android:name="flutterEmbedding"
-            android:value="2" />
     </application>
 </manifest>

--- a/flutter_app/mrs_unkwn_app/lib/app.dart
+++ b/flutter_app/mrs_unkwn_app/lib/app.dart
@@ -18,7 +18,7 @@ class MrsUnkwnApp extends StatelessWidget {
         title: 'Mrs-Unkwn',
         theme: ThemeData(primarySwatch: Colors.blue),
         routerConfig: AppRouter.router,
-        localizationsDelegates: const [
+        localizationsDelegates: [
           AppLocalizations.delegate,
           GlobalMaterialLocalizations.delegate,
           GlobalWidgetsLocalizations.delegate,

--- a/flutter_app/mrs_unkwn_app/lib/features/family/presentation/pages/create_family_page.dart
+++ b/flutter_app/mrs_unkwn_app/lib/features/family/presentation/pages/create_family_page.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 
 import '../../../../core/di/service_locator.dart';
 import '../../data/repositories/family_repository.dart';

--- a/flutter_app/mrs_unkwn_app/lib/features/family/presentation/pages/family_dashboard_page.dart
+++ b/flutter_app/mrs_unkwn_app/lib/features/family/presentation/pages/family_dashboard_page.dart
@@ -1,10 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:go_router/go_router.dart';
 import 'dart:async';
 
 import '../../../../core/permissions/family_permissions.dart';
-import '../../../../core/routing/route_constants.dart';
 import '../../../../core/di/service_locator.dart';
 import '../../data/models/family.dart';
 import '../../data/services/family_service.dart';
@@ -87,9 +85,6 @@ class _FamilyDashboardPageState extends State<FamilyDashboardPage> {
           }
           if (state is FamilyLoaded) {
             final family = state.family;
-            final members = family.members ?? [];
-            final activeMembers = members.length; // Placeholder
-
             return RefreshIndicator(
               onRefresh: _refresh,
               child: SingleChildScrollView(

--- a/flutter_app/mrs_unkwn_app/lib/features/monitoring/data/services/activity_monitoring_service.dart
+++ b/flutter_app/mrs_unkwn_app/lib/features/monitoring/data/services/activity_monitoring_service.dart
@@ -1,7 +1,6 @@
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
-import 'dart:typed_data';
 
 import 'package:hive_flutter/hive_flutter.dart';
 

--- a/flutter_app/mrs_unkwn_app/lib/features/monitoring/data/services/device_info_service.dart
+++ b/flutter_app/mrs_unkwn_app/lib/features/monitoring/data/services/device_info_service.dart
@@ -84,8 +84,8 @@ class DeviceInfoService {
         freeRam = int.tryParse(RegExp(r'\d+').firstMatch(line)?.group(0) ?? '');
       }
     }
-    if (totalRam != null) totalRam = (totalRam! / 1024).round();
-    if (freeRam != null) freeRam = (freeRam! / 1024).round();
+    if (totalRam != null) totalRam = (totalRam / 1024).round();
+    if (freeRam != null) freeRam = (freeRam / 1024).round();
 
     return {
       'timestamp': DateTime.now().toIso8601String(),

--- a/flutter_app/mrs_unkwn_app/lib/features/monitoring/data/services/monitoring_sync_service.dart
+++ b/flutter_app/mrs_unkwn_app/lib/features/monitoring/data/services/monitoring_sync_service.dart
@@ -1,7 +1,6 @@
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
-import 'dart:typed_data';
 
 import 'package:encrypt/encrypt.dart' as encrypt;
 import 'package:flutter/foundation.dart';

--- a/flutter_app/mrs_unkwn_app/lib/features/tutoring/data/services/voice_input_service.dart
+++ b/flutter_app/mrs_unkwn_app/lib/features/tutoring/data/services/voice_input_service.dart
@@ -30,11 +30,13 @@ class VoiceInputService {
     }
     _speech.listen(
       onResult: (res) => onResult(res.recognizedWords),
-      listenMode: stt.ListenMode.dictation,
       onSoundLevelChange: onSoundLevel,
       localeId: await _detectLocale(),
-      cancelOnError: true,
-      partialResults: false,
+      listenOptions: stt.SpeechListenOptions(
+        listenMode: stt.ListenMode.dictation,
+        cancelOnError: true,
+        partialResults: false,
+      ),
     );
   }
 

--- a/flutter_app/mrs_unkwn_app/test/learning_session_service_test.dart
+++ b/flutter_app/mrs_unkwn_app/test/learning_session_service_test.dart
@@ -3,7 +3,6 @@ import 'package:hive_flutter/hive_flutter.dart';
 import 'package:mocktail/mocktail.dart';
 
 import 'helpers/test_helpers.dart';
-import 'package:mrs_unkwn_app/core/storage/secure_storage_service.dart';
 import 'package:mrs_unkwn_app/features/tutoring/data/services/learning_session_service.dart';
 
 void main() {


### PR DESCRIPTION
## Summary
- reopen multi-platform support step in roadmap with comment about missing desktop platforms
- clean Flutter project to use embedding v2 and fix analyzer warnings
- document maintenance in changelog and prompt

## Testing
- `flutter analyze`
- `npm test` *(fails: ts-node not found)*
- `pytest codex/tests`

------
https://chatgpt.com/codex/tasks/task_e_6898791dd98c832e98f79734749f00c4