### PR TITLE
doc: note release build issues for multi-platform support

### DIFF
--- a/codex/daten/changelog.md
+++ b/codex/daten/changelog.md
@@ -918,3 +918,7 @@
 - Wrapper `scripts/build_android_release.sh` und `scripts/build_android_release.ps1` hinzugefügt.
 - README um Hinweise zum neuen Build-Prozess erweitert.
 - Roadmap und Prompt aktualisiert.
+### Phase 1: Flutter-Projekt mit Multi-Platform-Support re-verifiziert - 2025-10-23
+- `pubspec.yaml` um `flutter: ">=3.16.0"` ergänzt
+- `android/build.gradle` mit `ext.flutter` für SDK-Versionen erweitert
+- `flutter build apk --release` fehlgeschlagen: fehlende Flutter-Maven-Artefakte (`io.flutter:flutter_embedding_release`)

--- a/codex/daten/prompt.md
+++ b/codex/daten/prompt.md
@@ -1,10 +1,11 @@
-# Nächster Schritt: GitHub Actions für Android-Release-Build einrichten
+# Nächster Schritt: Flutter-Projekt mit Multi-Platform-Support erstellen
 
 ## Status
 - Phase 0 abgeschlossen ✓
 - Produktions-Setup-Skript erstellt ✓
 - Disk-Space-Plugin ersetzt & Backend-Build-Skripte ergänzt ✓
 - Android namespace Fixer & Release-Build-Skripte hinzugefügt ✓
+- Flutter-Projekt Multi-Platform-Support re-verifiziert – Build schlägt aktuell wegen fehlender Flutter-Maven-Artefakte fehl ✗
 
 ## Referenzen
 - `/README.md`
@@ -13,16 +14,16 @@
 - `/codex/daten/changelog.md`
 
 ## Nächste Aufgabe
-GitHub Actions Workflow erstellen, der `scripts/build_android_release.sh` ausführt und das APK als Artefakt bereitstellt.
+Fehlende Flutter-Maven-Artefakte beheben und Release-Build erfolgreich ausführen.
 
 ### Vorbereitungen
 - README und Roadmap prüfen.
 
 ### Implementierungsschritte
-- Workflow-Datei `.github/workflows/build-android-release.yml` anlegen.
-- Container `cirrusci/flutter:stable` verwenden.
-- `scripts/build_android_release.sh` ausführen.
-- Artefakt `build/app/outputs/flutter-apk/app-release.apk` hochladen.
+- `flutter clean`
+- `flutter pub get`
+- Fehlende Flutter-Maven-Artefakte (`io.flutter:flutter_embedding_release`) bereitstellen oder Repositories konfigurieren
+- `flutter build apk --release`
 
 ### Validierung
 - `npm test`

--- a/codex/daten/roadmap.md
+++ b/codex/daten/roadmap.md
@@ -19,7 +19,7 @@ Details: Erstelle ein neues Git-Repository mit `git init`. Füge eine .gitignore
 [x] Flutter SDK installieren und Entwicklungsumgebung einrichten:
 Details: Lade Flutter SDK von flutter.dev herunter. Extrahiere das SDK nach `C:\flutter` (Windows) oder `~/flutter` (macOS/Linux). Füge Flutter-Pfad zur PATH-Umgebungsvariable hinzu. Führe `flutter doctor` aus und behebe alle gemeldeten Probleme. Installiere Android Studio oder VS Code mit Flutter/Dart-Erweiterungen. Konfiguriere Android SDK mit API Level 21+ und iOS Deployment Target 11.0+.
 
-[ ] Flutter-Projekt mit Multi-Platform-Support erstellen <!-- TODO: pubspec SDK-Minimum auf ≥3.16.0 aktualisieren (aktuell Dart 3.5.3); Desktop-Verzeichnisse jetzt vorhanden -->
+[ ] Flutter-Projekt mit Multi-Platform-Support erstellen <!-- TODO: Dart SDK bleibt bei ≥3.5.0; fehlende Flutter-Maven-Artefakte verhindern Release-Build -->
 Details: Navigiere in den `flutter_app/`-Ordner. Führe `flutter create --org com.mrsunkwn --platforms android,ios,web,windows,macos,linux mrs_unkwn_app` aus. Öffne `pubspec.yaml` und setze `flutter` Version auf minimum "3.16.0". Entferne Standard-Demo-Code aus `lib/main.dart`. Erstelle Basis-Ordnerstruktur in `lib/`: `core/`, `features/`, `shared/`, `platform_channels/`.
 
 [x] pubspec.yaml mit erforderlichen Dependencies konfigurieren:

--- a/flutter_app/mrs_unkwn_app/android/build.gradle
+++ b/flutter_app/mrs_unkwn_app/android/build.gradle
@@ -1,4 +1,11 @@
 rootProject.buildDir = '../build'
+ext {
+    flutter = [
+        minSdkVersion: 23,
+        compileSdkVersion: 35,
+        targetSdkVersion: 35
+    ]
+}
 subprojects {
     project.buildDir = "${rootProject.buildDir}/${project.name}"
 }

--- a/flutter_app/mrs_unkwn_app/pubspec.yaml
+++ b/flutter_app/mrs_unkwn_app/pubspec.yaml
@@ -4,6 +4,7 @@ description: Mrs-Unkwn Flutter app
 environment:
   # CI hat Dart 3.5.3 -> Constraint so setzen, dass 3.5.x erlaubt ist.
   sdk: ">=3.5.0 <4.0.0"
+  flutter: ">=3.16.0"
 
 dependencies:
   flutter:


### PR DESCRIPTION
## Summary
- declare Flutter 3.16+ requirement in app pubspec
- define `ext.flutter` SDK versions for Android build
- log failed release build and missing Flutter Maven artifacts

## Testing
- `npm test` *(fails: ts-node not found)*
- `pytest codex/tests`
- `flutter test` *(fails: multiple MissingPluginException and assertion errors)*
- `flutter build apk --release` *(fails: missing io.flutter:flutter_embedding_release)*

------
https://chatgpt.com/codex/tasks/task_e_6898c75a09d8832e846d0788ddc060e1