### PR TITLE
Add Flutter Maven repository for Android build

### DIFF
--- a/codex/daten/changelog.md
+++ b/codex/daten/changelog.md
@@ -922,3 +922,7 @@
 - `pubspec.yaml` um `flutter: ">=3.16.0"` ergänzt
 - `android/build.gradle` mit `ext.flutter` für SDK-Versionen erweitert
 - `flutter build apk --release` fehlgeschlagen: fehlende Flutter-Maven-Artefakte (`io.flutter:flutter_embedding_release`)
+### Phase 1: Flutter-Projekt mit Multi-Platform-Support – Maven-Repo-Fix - 2025-10-24
+- `android/settings.gradle` um Flutter-Maven-Repository ergänzt
+- `flutter clean`, `flutter pub get` und Namespace-Fixer ausgeführt
+- `flutter build apk --release` gestartet (Abhängigkeiten werden heruntergeladen; Build noch nicht abgeschlossen)

--- a/codex/daten/prompt.md
+++ b/codex/daten/prompt.md
@@ -5,7 +5,7 @@
 - Produktions-Setup-Skript erstellt ✓
 - Disk-Space-Plugin ersetzt & Backend-Build-Skripte ergänzt ✓
 - Android namespace Fixer & Release-Build-Skripte hinzugefügt ✓
-- Flutter-Projekt Multi-Platform-Support re-verifiziert – Build schlägt aktuell wegen fehlender Flutter-Maven-Artefakte fehl ✗
+- Flutter-Projekt Multi-Platform-Support re-verifiziert – Maven-Repository ergänzt, Release-Build lädt noch Abhängigkeiten ✗
 
 ## Referenzen
 - `/README.md`
@@ -14,7 +14,7 @@
 - `/codex/daten/changelog.md`
 
 ## Nächste Aufgabe
-Fehlende Flutter-Maven-Artefakte beheben und Release-Build erfolgreich ausführen.
+Release-Build mit vollständig geladenen Abhängigkeiten erfolgreich abschließen.
 
 ### Vorbereitungen
 - README und Roadmap prüfen.
@@ -22,7 +22,6 @@ Fehlende Flutter-Maven-Artefakte beheben und Release-Build erfolgreich ausführe
 ### Implementierungsschritte
 - `flutter clean`
 - `flutter pub get`
-- Fehlende Flutter-Maven-Artefakte (`io.flutter:flutter_embedding_release`) bereitstellen oder Repositories konfigurieren
 - `flutter build apk --release`
 
 ### Validierung

--- a/codex/daten/roadmap.md
+++ b/codex/daten/roadmap.md
@@ -19,7 +19,7 @@ Details: Erstelle ein neues Git-Repository mit `git init`. Füge eine .gitignore
 [x] Flutter SDK installieren und Entwicklungsumgebung einrichten:
 Details: Lade Flutter SDK von flutter.dev herunter. Extrahiere das SDK nach `C:\flutter` (Windows) oder `~/flutter` (macOS/Linux). Füge Flutter-Pfad zur PATH-Umgebungsvariable hinzu. Führe `flutter doctor` aus und behebe alle gemeldeten Probleme. Installiere Android Studio oder VS Code mit Flutter/Dart-Erweiterungen. Konfiguriere Android SDK mit API Level 21+ und iOS Deployment Target 11.0+.
 
-[ ] Flutter-Projekt mit Multi-Platform-Support erstellen <!-- TODO: Dart SDK bleibt bei ≥3.5.0; fehlende Flutter-Maven-Artefakte verhindern Release-Build -->
+[ ] Flutter-Projekt mit Multi-Platform-Support erstellen <!-- TODO: Maven-Repository ergänzt; Release-Build läuft noch wegen umfangreicher Abhängigkeits-Downloads -->
 Details: Navigiere in den `flutter_app/`-Ordner. Führe `flutter create --org com.mrsunkwn --platforms android,ios,web,windows,macos,linux mrs_unkwn_app` aus. Öffne `pubspec.yaml` und setze `flutter` Version auf minimum "3.16.0". Entferne Standard-Demo-Code aus `lib/main.dart`. Erstelle Basis-Ordnerstruktur in `lib/`: `core/`, `features/`, `shared/`, `platform_channels/`.
 
 [x] pubspec.yaml mit erforderlichen Dependencies konfigurieren:

--- a/flutter_app/mrs_unkwn_app/android/settings.gradle
+++ b/flutter_app/mrs_unkwn_app/android/settings.gradle
@@ -13,6 +13,7 @@ pluginManagement {
         google()
         mavenCentral()
         gradlePluginPortal()
+        maven { url = uri("https://storage.googleapis.com/download.flutter.io") }
     }
 }
 
@@ -27,6 +28,7 @@ dependencyResolutionManagement {
     repositories {
         google()
         mavenCentral()
+        maven { url = uri("https://storage.googleapis.com/download.flutter.io") }
     }
 }
 


### PR DESCRIPTION
## Summary
- add Flutter Maven repository to Android `settings.gradle` to resolve missing embedding artifacts
- document pending release build in changelog, roadmap, and prompt

## Testing
- `npm test` *(fails: Cannot find module 'express')*
- `pytest codex/tests`
- `flutter test` *(fails: MissingPluginException & toARGB32 error)*

------
https://chatgpt.com/codex/tasks/task_e_6898ea024f54832e91ecaa9217cdb616