### PR TITLE
chore: align android gradle wrapper with 8.7

### DIFF
--- a/codex/daten/changelog.md
+++ b/codex/daten/changelog.md
@@ -930,3 +930,7 @@
 ### Wartung: Backend Docker-Build korrigiert - 2025-10-25
 - `Dockerfile` und `Dockerfile.backend` installieren nun Dev-Dependencies, bauen das Projekt und prunen sie anschließend
 - Backend-Container erstellt die `dist/`-Artefakte erfolgreich und startet
+
+### Wartung: Gradle 8.7 Update & Build-Bereinigung - 2025-10-26
+- Gradle Wrapper auf Version 8.7 aktualisiert und veraltete Flags in `android/gradle.properties` entfernt
+- Release-Build erneut gestartet, bricht jedoch weiterhin mit langer Abhängigkeitskompilierung ab

--- a/codex/daten/prompt.md
+++ b/codex/daten/prompt.md
@@ -5,7 +5,7 @@
 - Produktions-Setup-Skript erstellt ✓
 - Disk-Space-Plugin ersetzt & Backend-Build-Skripte ergänzt ✓
 - Android namespace Fixer & Release-Build-Skripte hinzugefügt ✓
-- Flutter-Projekt Multi-Platform-Support re-verifiziert – Maven-Repository ergänzt, Release-Build lädt noch Abhängigkeiten ✗
+- Flutter-Projekt Multi-Platform-Support re-verifiziert – Gradle 8.7 gesetzt, Release-Build bricht weiterhin während Abhängigkeitskompilierung ab ✗
 - Backend Docker-Build korrigiert ✓
 
 ## Referenzen

--- a/codex/daten/roadmap.md
+++ b/codex/daten/roadmap.md
@@ -19,7 +19,7 @@ Details: Erstelle ein neues Git-Repository mit `git init`. Füge eine .gitignore
 [x] Flutter SDK installieren und Entwicklungsumgebung einrichten:
 Details: Lade Flutter SDK von flutter.dev herunter. Extrahiere das SDK nach `C:\flutter` (Windows) oder `~/flutter` (macOS/Linux). Füge Flutter-Pfad zur PATH-Umgebungsvariable hinzu. Führe `flutter doctor` aus und behebe alle gemeldeten Probleme. Installiere Android Studio oder VS Code mit Flutter/Dart-Erweiterungen. Konfiguriere Android SDK mit API Level 21+ und iOS Deployment Target 11.0+.
 
-[ ] Flutter-Projekt mit Multi-Platform-Support erstellen <!-- TODO: Maven-Repository ergänzt; Release-Build läuft noch wegen umfangreicher Abhängigkeits-Downloads -->
+[ ] Flutter-Projekt mit Multi-Platform-Support erstellen <!-- TODO: Gradle 8.7 gesetzt; Release-Build bricht während Abhängigkeitskompilierung ab -->
 Details: Navigiere in den `flutter_app/`-Ordner. Führe `flutter create --org com.mrsunkwn --platforms android,ios,web,windows,macos,linux mrs_unkwn_app` aus. Öffne `pubspec.yaml` und setze `flutter` Version auf minimum "3.16.0". Entferne Standard-Demo-Code aus `lib/main.dart`. Erstelle Basis-Ordnerstruktur in `lib/`: `core/`, `features/`, `shared/`, `platform_channels/`.
 
 [x] pubspec.yaml mit erforderlichen Dependencies konfigurieren:

--- a/flutter_app/mrs_unkwn_app/android/gradle.properties
+++ b/flutter_app/mrs_unkwn_app/android/gradle.properties
@@ -1,10 +1,6 @@
 org.gradle.jvmargs=-Xmx4g -Dkotlin.daemon.jvm.options=-Xmx2g
 android.useAndroidX=true
 android.enableJetifier=true
-android.enableR8=true
 # KRITISCH: Diese Zeile MUSS vorhanden sein
 flutter.embedding=2
-android.defaults.buildfeatures.buildconfig=true
 android.nonTransitiveRClass=false
-
-android.overrideVersionCheck=true

--- a/flutter_app/mrs_unkwn_app/android/gradle/wrapper/gradle-wrapper.properties
+++ b/flutter_app/mrs_unkwn_app/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
## Summary
- upgrade Android Gradle wrapper to 8.7 and clean obsolete flags
- document Gradle update and outstanding release build in roadmap, prompt, and changelog

## Testing
- `npm test` *(fails: Cannot find module 'express')*
- `pytest codex/tests`
- `flutter test` *(fails: MissingPluginException, geolocator_android toARGB32)*

------
https://chatgpt.com/codex/tasks/task_e_689904f73e20832e889464a583694239