### PR TITLE
docs: note release build dependency hang

### DIFF
--- a/codex/daten/changelog.md
+++ b/codex/daten/changelog.md
@@ -930,3 +930,7 @@
 ### Wartung: Backend Docker-Build korrigiert - 2025-10-25
 - `Dockerfile` und `Dockerfile.backend` installieren nun Dev-Dependencies, bauen das Projekt und prunen sie anschließend
 - Backend-Container erstellt die `dist/`-Artefakte erfolgreich und startet
+
+### Phase 1: Release-Build-Abhängigkeiten prüfen - 2025-10-26
+- `flutter build apk --release` erneut ausgeführt; Gradle-Task `assembleRelease` hängt weiterhin beim Laden von Android-Abhängigkeiten
+- Roadmap und Prompt aktualisiert

--- a/codex/daten/prompt.md
+++ b/codex/daten/prompt.md
@@ -7,6 +7,7 @@
 - Android namespace Fixer & Release-Build-Skripte hinzugefügt ✓
 - Flutter-Projekt Multi-Platform-Support re-verifiziert – Maven-Repository ergänzt, Release-Build lädt noch Abhängigkeiten ✗
 - Backend Docker-Build korrigiert ✓
+- Release-Build erneut gestartet – Gradle-Task `assembleRelease` hängt beim Laden der Android-Abhängigkeiten ✗
 
 ## Referenzen
 - `/README.md`

--- a/codex/daten/roadmap.md
+++ b/codex/daten/roadmap.md
@@ -19,7 +19,7 @@ Details: Erstelle ein neues Git-Repository mit `git init`. Füge eine .gitignore
 [x] Flutter SDK installieren und Entwicklungsumgebung einrichten:
 Details: Lade Flutter SDK von flutter.dev herunter. Extrahiere das SDK nach `C:\flutter` (Windows) oder `~/flutter` (macOS/Linux). Füge Flutter-Pfad zur PATH-Umgebungsvariable hinzu. Führe `flutter doctor` aus und behebe alle gemeldeten Probleme. Installiere Android Studio oder VS Code mit Flutter/Dart-Erweiterungen. Konfiguriere Android SDK mit API Level 21+ und iOS Deployment Target 11.0+.
 
-[ ] Flutter-Projekt mit Multi-Platform-Support erstellen <!-- TODO: Maven-Repository ergänzt; Release-Build läuft noch wegen umfangreicher Abhängigkeits-Downloads -->
+[ ] Flutter-Projekt mit Multi-Platform-Support erstellen <!-- TODO: Release-Build hängt weiterhin bei 'assembleRelease' während Android-Abhängigkeiten geladen werden -->
 Details: Navigiere in den `flutter_app/`-Ordner. Führe `flutter create --org com.mrsunkwn --platforms android,ios,web,windows,macos,linux mrs_unkwn_app` aus. Öffne `pubspec.yaml` und setze `flutter` Version auf minimum "3.16.0". Entferne Standard-Demo-Code aus `lib/main.dart`. Erstelle Basis-Ordnerstruktur in `lib/`: `core/`, `features/`, `shared/`, `platform_channels/`.
 
 [x] pubspec.yaml mit erforderlichen Dependencies konfigurieren:


### PR DESCRIPTION
## Summary
- document that release build still hangs while Gradle downloads Android dependencies
- record release build attempt in changelog and prompt
- note pending multi-platform setup in roadmap

## Testing
- `flutter build apk --release` *(fails: Running Gradle task 'assembleRelease'...)*
- `npm test` *(fails: Cannot find module 'express')*
- `pytest codex/tests`
- `flutter test` *(fails: toARGB32 not defined / test compilation errors)*

------
https://chatgpt.com/codex/tasks/task_e_68990c0bcd1c832e9fa14bf0f5acef7e