### PR TITLE
Patch geolocator plugin and upgrade AGP

### DIFF
--- a/codex/daten/changelog.md
+++ b/codex/daten/changelog.md
@@ -934,3 +934,9 @@
 ### Wartung: Gradle 8.7 Update & Build-Bereinigung - 2025-10-26
 - Gradle Wrapper auf Version 8.7 aktualisiert und veraltete Flags in `android/gradle.properties` entfernt
 - Release-Build erneut gestartet, bricht jedoch weiterhin mit langer Abhängigkeitskompilierung ab
+
+### Phase 1: geolocator patch & AGP update - 2025-10-27
+- Patch script ersetzt toARGB32 durch value im geolocator_android Plugin.
+- build_android_release.sh generiert L10n-Dateien und ruft Patch-Skript auf.
+- Android settings.gradle auf AGP 8.6.0 aktualisiert.
+- Release-Build weiterhin fehlgeschlagen: Dependency erfordert AGP >=8.6, weitere Analyse nötig.

--- a/codex/daten/prompt.md
+++ b/codex/daten/prompt.md
@@ -1,12 +1,10 @@
-# Nächster Schritt: Release-Build mit vollständig geladenen Abhängigkeiten erfolgreich abschließen
+# Nächster Schritt: Release-Build nach AGP 8.6.0 Upgrade stabilisieren
 
 ## Status
-- Phase 0 abgeschlossen ✓
-- Produktions-Setup-Skript erstellt ✓
-- Disk-Space-Plugin ersetzt & Backend-Build-Skripte ergänzt ✓
-- Android namespace Fixer & Release-Build-Skripte hinzugefügt ✓
-- Flutter-Projekt Multi-Platform-Support re-verifiziert – Gradle 8.7 gesetzt, Release-Build bricht weiterhin während Abhängigkeitskompilierung ab ✗
-- Backend Docker-Build korrigiert ✓
+- geolocator_android Plugin gepatcht (toARGB32 -> value)
+- build_android_release.sh generiert L10n-Dateien und patcht Plugin
+- Android settings.gradle auf AGP 8.6.0 angehoben
+- Release-Build weiterhin fehlgeschlagen (Abhängigkeits-/Gradle-Probleme)
 
 ## Referenzen
 - `/README.md`
@@ -15,7 +13,7 @@
 - `/codex/daten/changelog.md`
 
 ## Nächste Aufgabe
-Release-Build mit vollständig geladenen Abhängigkeiten erfolgreich abschließen.
+Release-Build erneut ausführen und verbliebene Build-Probleme analysieren.
 
 ### Vorbereitungen
 - README und Roadmap prüfen.
@@ -23,6 +21,9 @@ Release-Build mit vollständig geladenen Abhängigkeiten erfolgreich abschließe
 ### Implementierungsschritte
 - `flutter clean`
 - `flutter pub get`
+- `flutter gen-l10n`
+- `scripts/patch_geolocator_android.sh`
+- `dart run tool/fix_android_namespaces.dart`
 - `flutter build apk --release`
 
 ### Validierung

--- a/codex/daten/roadmap.md
+++ b/codex/daten/roadmap.md
@@ -19,7 +19,7 @@ Details: Erstelle ein neues Git-Repository mit `git init`. Füge eine .gitignore
 [x] Flutter SDK installieren und Entwicklungsumgebung einrichten:
 Details: Lade Flutter SDK von flutter.dev herunter. Extrahiere das SDK nach `C:\flutter` (Windows) oder `~/flutter` (macOS/Linux). Füge Flutter-Pfad zur PATH-Umgebungsvariable hinzu. Führe `flutter doctor` aus und behebe alle gemeldeten Probleme. Installiere Android Studio oder VS Code mit Flutter/Dart-Erweiterungen. Konfiguriere Android SDK mit API Level 21+ und iOS Deployment Target 11.0+.
 
-[ ] Flutter-Projekt mit Multi-Platform-Support erstellen <!-- TODO: Gradle 8.7 gesetzt; Release-Build bricht während Abhängigkeitskompilierung ab -->
+[ ] Flutter-Projekt mit Multi-Platform-Support erstellen <!-- TODO: Release-Build scheitert trotz geolocator_patch & AGP 8.6.0 -->
 Details: Navigiere in den `flutter_app/`-Ordner. Führe `flutter create --org com.mrsunkwn --platforms android,ios,web,windows,macos,linux mrs_unkwn_app` aus. Öffne `pubspec.yaml` und setze `flutter` Version auf minimum "3.16.0". Entferne Standard-Demo-Code aus `lib/main.dart`. Erstelle Basis-Ordnerstruktur in `lib/`: `core/`, `features/`, `shared/`, `platform_channels/`.
 
 [x] pubspec.yaml mit erforderlichen Dependencies konfigurieren:

--- a/flutter_app/mrs_unkwn_app/android/settings.gradle
+++ b/flutter_app/mrs_unkwn_app/android/settings.gradle
@@ -19,7 +19,7 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version "8.5.0" apply false
+    id "com.android.application" version "8.6.0" apply false
     id "org.jetbrains.kotlin.android" version "1.9.24" apply false
 }
 

--- a/scripts/build_android_release.sh
+++ b/scripts/build_android_release.sh
@@ -5,5 +5,7 @@ APP_DIR="$SCRIPT_DIR/../flutter_app/mrs_unkwn_app"
 cd "$APP_DIR"
 flutter clean
 flutter pub get
+flutter gen-l10n
+"$SCRIPT_DIR"/patch_geolocator_android.sh
 dart run tool/fix_android_namespaces.dart
 flutter build apk --release

--- a/scripts/patch_geolocator_android.sh
+++ b/scripts/patch_geolocator_android.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+PLUGIN_DIR="$(flutter pub cache path geolocator_android 2>/dev/null || true)"
+if [[ -z "${PLUGIN_DIR}" ]]; then
+  PLUGIN_DIR="$HOME/.pub-cache/hosted/pub.dev/geolocator_android-5.0.2"
+fi
+TARGET_FILE="$PLUGIN_DIR/lib/src/types/foreground_settings.dart"
+if [[ -f "$TARGET_FILE" ]]; then
+  sed -i "s/color?.toARGB32()/color?.value/" "$TARGET_FILE"
+fi


### PR DESCRIPTION
## Summary
- patch geolocator_android to remove deprecated `toARGB32`
- run `flutter gen-l10n` and patch script in Android release build
- upgrade Android Gradle plugin to 8.6.0

## Testing
- `npm test` *(fails: Cannot find module 'express')*
- `pytest codex/tests`
- `flutter test` *(fails: MissingPluginException on getApplicationDocumentsDirectory)*
- `flutter build apk --release` *(fails: Dependency ':qr_code_scanner' requires core library desugaring)*

------
https://chatgpt.com/codex/tasks/task_e_689913206c2c832eb65248af36e4d9d2